### PR TITLE
Enable AndroidX

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,6 @@
 
 org.gradle.configuration-cache=true
 
+
+android.useAndroidX=true
+


### PR DESCRIPTION
## Summary
- allow AndroidX dependencies by setting `android.useAndroidX=true`

## Testing
- `gradle wrapper`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c58cb9434832fa27740b3f262e16f