### PR TITLE
Fix missing Material theme

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,5 +42,6 @@ dependencies {
     implementation platform('androidx.compose:compose-bom:2023.10.01')
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.material3:material3'
+    implementation 'com.google.android.material:material:1.11.0'
     implementation 'androidx.navigation:navigation-compose:2.7.7'
 }


### PR DESCRIPTION
## Summary
- include Android Material library so XML theme `Theme.RandomQr` can link

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5a0da1a4832f93e71694e92d5f2a