### PR TITLE
Fix build warnings and Compose compiler setup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,7 +32,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.5'
+        kotlinCompilerExtensionVersion '1.5.10'
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.randomqr">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
         android:allowBackup="true"
         android:label="@string/app_name"

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@ org.gradle.configuration-cache=true
 
 android.useAndroidX=true
 
+android.suppressUnsupportedCompileSdk=35


### PR DESCRIPTION
## Summary
- bump Compose compiler to 1.5.10
- remove deprecated package attribute in AndroidManifest
- suppress compileSdk warning in gradle.properties

## Testing
- `gradle wrapper`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5c8f819c832fbfcd87b3c8b51bdd