### PR TITLE
Add Compose preview tooling dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,5 +40,7 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.8.0'
     implementation platform('androidx.compose:compose-bom:2023.10.01')
     implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
     implementation 'androidx.compose.material3:material3'
 }


### PR DESCRIPTION
## Summary
- include Compose tooling artifacts for preview support

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d191ee790832fb812766c80a3f9fd