### PR TITLE
Fix unsupported Android SDK warning

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace 'com.example.basic'
-    compileSdk 35
+    compileSdk 34
 
     defaultConfig {
         applicationId 'com.example.basic'
         minSdk 24
-        targetSdk 35
+        targetSdk 34
         versionCode 1
         versionName '1.0'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
-android.suppressUnsupportedCompileSdk=35


### PR DESCRIPTION
## Summary
- update compileSdk and targetSdk to 34
- remove `android.suppressUnsupportedCompileSdk`

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1a51890c832f8a13f445546b500b