### PR TITLE
Fix attendance card clipping

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceScreen.kt
@@ -84,7 +84,7 @@ private fun SubjectCard(item: Subject, isLab: Boolean) {
     Card(
         modifier = Modifier
             .padding(6.dp)
-            .height(130.dp),
+            .height(150.dp),
         colors = CardDefaults.cardColors(containerColor = backgroundColor(item.attendance)),
         border = if (isLab) BorderStroke(2.dp, Color(0xFF757575)) else null
     ) {
@@ -93,14 +93,14 @@ private fun SubjectCard(item: Subject, isLab: Boolean) {
                 .fillMaxSize()
                 .padding(8.dp)
         ) {
-            Column(modifier = Modifier.weight(0.3f)) {
+            Column(modifier = Modifier.weight(0.4f)) {
                 Text(text = item.name, fontSize = 18.sp, fontWeight = FontWeight.SemiBold, color = Color(0xFF212121))
                 Text(text = item.code, fontSize = 14.sp, color = Color(0xFF212121))
             }
             Spacer(modifier = Modifier.weight(0.1f))
             Row(
                 modifier = Modifier
-                    .weight(0.6f)
+                    .weight(0.5f)
                     .fillMaxSize(),
                 verticalAlignment = Alignment.Bottom,
                 horizontalArrangement = androidx.compose.foundation.layout.Arrangement.SpaceBetween

--- a/vit-student-app/src/screens/Attendance.tsx
+++ b/vit-student-app/src/screens/Attendance.tsx
@@ -31,7 +31,7 @@ const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const CARD_MARGIN = 12;
  
 const CARD_WIDTH = (SCREEN_WIDTH - CARD_MARGIN * 3) / 2 - 8;
-const CARD_HEIGHT = 130;
+const CARD_HEIGHT = 150;
  
 
 function getBackgroundColor(p: number): string {
@@ -159,7 +159,7 @@ const styles = StyleSheet.create({
     opacity: 0.8,
   },
   header: {
-    flex: 0.3,
+    flex: 0.4,
     justifyContent: 'center',
     paddingHorizontal: 8,
     paddingTop: 12,
@@ -174,7 +174,7 @@ const styles = StyleSheet.create({
     color: '#212121',
   },
   body: {
-    flex: 0.7,
+    flex: 0.6,
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'flex-end',


### PR DESCRIPTION
## Summary
- increase card height so course codes display fully
- tweak layout weights for text and icons

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_685d2d274f18832f865b2db9d4c59e5f