### PR TITLE
Fix wrong icon style on attendance screen

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Card
@@ -66,7 +66,7 @@ private fun backgroundColor(p: Int): Color = when {
 private fun iconFor(p: Int) = when {
     p >= 75 -> Icons.Default.CheckCircle
     p >= 70 -> Icons.Default.Warning
-    else -> Icons.Default.Close
+    else -> Icons.Default.Cancel
 }
 
 private fun iconColor(p: Int): Color = when {


### PR DESCRIPTION
## Summary
- use `Icons.Default.Cancel` for low attendance state so it has a circular background like the tick icon

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_685d2f46a140832fba5f50c35587418c