### PR TITLE
Improve meal cards and rating dialog

### DIFF
--- a/app/src/main/java/com/example/basic/FoodMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/FoodMenuScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
@@ -219,11 +220,12 @@ private fun MealCard(
     Card(
         shape = RoundedCornerShape(8.dp),
         colors = CardDefaults.cardColors(containerColor = background),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
         modifier = Modifier
             .fillMaxWidth()
-            .heightIn(min = 130.dp)
-            .graphicsLayer { alpha = if (ended) 0.6f else 1f }
+            .height(110.dp)
+            .shadow(6.dp, RoundedCornerShape(8.dp))
+            .graphicsLayer { this.alpha = if (ended) 0.6f else 1f }
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -253,9 +255,10 @@ private fun MealCard(
                     )
                     Spacer(Modifier.width(4.dp))
                     Text(text = if (ended) "Done" else status, style = MaterialTheme.typography.labelSmall, color = Color(0xFF333333))
-                    if (!ended && status == "Upcoming") {
+                    if (!ended) {
                         Spacer(Modifier.width(8.dp))
-                        val diff = start.timeInMillis - now.time
+                        val target = if (status == "Upcoming") start.timeInMillis else end.timeInMillis
+                        val diff = (target - now.time).coerceAtLeast(0)
                         val h = diff / 3600000
                         val m = (diff % 3600000) / 60000
                         val s = (diff % 60000) / 1000
@@ -318,7 +321,10 @@ fun RatingDialog(meal: Meal, onDismiss: () -> Unit, onSubmit: (Int) -> Unit) {
                             tint = Color.Red,
                             modifier = Modifier
                                 .size(32.dp)
-                                .clickable { rating = i }
+                                .clickable(
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    indication = null
+                                ) { rating = i }
                         )
                     }
                 }


### PR DESCRIPTION
## Summary
- unify meal card sizing and add shadow to all cards
- show hours/minutes/seconds countdown for upcoming or ongoing meals
- remove ripple background from rating hearts
- fix missing imports for `shadow` and update alpha usage to avoid build errors

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to access jarfile gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685d37026e6c832f92bc5444bee78d1d