### PR TITLE
Fix dimmed card border in FoodMenuScreen

### DIFF
--- a/vit-student-app/src/screens/FoodMenuScreen.tsx
+++ b/vit-student-app/src/screens/FoodMenuScreen.tsx
@@ -378,7 +378,9 @@ const styles = StyleSheet.create({
     elevation: 2,
   },
   mealBlockEnded: {
-    opacity: 0.6,
+    // Use a lighter background instead of opacity so the text
+    // label doesn't show a white halo when the card is dimmed.
+    backgroundColor: '#ddd',
   },
   mealHeader: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- avoid white halo on text when meal card is dimmed

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d3a0f6a40832fa06939511d94f79e