### PR TITLE
Add Planner screen using Compose

### DIFF
--- a/app/src/main/java/com/example/basic/MainActivity.kt
+++ b/app/src/main/java/com/example/basic/MainActivity.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 
 import com.example.basic.FoodMenuScreen
 import com.example.basic.FoodSummaryScreen
+import com.example.basic.PlannerScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -92,6 +93,7 @@ fun BasicApp() {
                 contentAlignment = Alignment.Center
             ) {
                 when (selectedIndex) {
+                    1 -> PlannerScreen()
                     2 -> AttendanceScreen()
                     3 -> {
                         if (foodScreen == 0) {

--- a/app/src/main/java/com/example/basic/PlannerScreen.kt
+++ b/app/src/main/java/com/example/basic/PlannerScreen.kt
@@ -1,0 +1,114 @@
+package com.example.basic
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.draw.clip
+
+@Composable
+fun PlannerScreen() {
+    val days = WEEKLY_SCHEDULE.keys.toList()
+    var day by remember { mutableStateOf(days.first()) }
+    val classes = WEEKLY_SCHEDULE[day].orEmpty()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFFF0F2F5))
+    ) {
+        Text(
+            text = "Weekly Timetable",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = Color(0xFF333333),
+            modifier = Modifier
+                .padding(vertical = 16.dp, horizontal = 16.dp)
+        )
+
+        LazyRow(
+            modifier = Modifier.padding(bottom = 8.dp),
+            contentPadding = PaddingValues(horizontal = 16.dp)
+        ) {
+            items(days) { d ->
+                val selected = d == day
+                Text(
+                    text = d.take(3),
+                    fontSize = 14.sp,
+                    fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
+                    color = if (selected) Color.White else Color(0xFF333333),
+                    modifier = Modifier
+                        .padding(end = 8.dp)
+                        .clip(RoundedCornerShape(20.dp))
+                        .background(if (selected) Color(0xFF6C5CE7) else Color(0xFFE0E0E0))
+                        .clickable { day = d }
+                        .padding(horizontal = 12.dp, vertical = 8.dp)
+                )
+            }
+        }
+
+        LazyColumn(
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 4.dp)
+        ) {
+            items(classes) { cls ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 6.dp),
+                    colors = CardDefaults.cardColors(containerColor = Color.White),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 10.dp, horizontal = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = cls.course,
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                color = Color(0xFF333333)
+                            )
+                            Text(
+                                text = cls.faculty,
+                                fontSize = 12.sp,
+                                color = Color(0xFF666666),
+                                modifier = Modifier.padding(top = 2.dp)
+                            )
+                        }
+                        Column(horizontalAlignment = Alignment.End) {
+                            Text(
+                                text = "${cls.start} – ${cls.end}",
+                                fontSize = 12.sp,
+                                color = Color(0xFF333333)
+                            )
+                            Text(
+                                text = cls.room,
+                                fontSize = 10.sp,
+                                color = Color(0xFF666666),
+                                modifier = Modifier.padding(top = 2.dp)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/basic/WeeklySchedule.kt
+++ b/app/src/main/java/com/example/basic/WeeklySchedule.kt
@@ -1,0 +1,48 @@
+package com.example.basic
+
+// Data classes and sample schedule used for PlannerScreen
+
+data class ClassEntry(
+    val course: String,
+    val faculty: String,
+    val start: String,
+    val end: String,
+    val room: String
+)
+
+val WEEKLY_SCHEDULE: Map<String, List<ClassEntry>> = mapOf(
+    "Monday" to listOf(
+        ClassEntry("CSE1001", "Prof. Rao", "08:00", "08:50", "101"),
+        ClassEntry("MAT1002", "Dr. Singh", "09:00", "09:50", "201"),
+        ClassEntry("PHY1003", "Dr. Patel", "10:00", "10:50", "Lab 1"),
+        ClassEntry("ENG1004", "Ms. James", "11:00", "11:50", "305")
+    ),
+    "Tuesday" to listOf(
+        ClassEntry("CHE1005", "Dr. Verma", "08:00", "08:50", "202"),
+        ClassEntry("CSE1001", "Prof. Rao", "09:00", "09:50", "101"),
+        ClassEntry("MAT1002", "Dr. Singh", "10:00", "10:50", "201"),
+        ClassEntry("PHY1003", "Dr. Patel", "11:00", "11:50", "Lab 1")
+    ),
+    "Wednesday" to listOf(
+        ClassEntry("ENG1004", "Ms. James", "08:00", "08:50", "305"),
+        ClassEntry("CSE1001", "Prof. Rao", "09:00", "09:50", "101"),
+        ClassEntry("CHE1005", "Dr. Verma", "10:00", "10:50", "202"),
+        ClassEntry("MAT1002", "Dr. Singh", "11:00", "11:50", "201")
+    ),
+    "Thursday" to listOf(
+        ClassEntry("PHY1003", "Dr. Patel", "08:00", "08:50", "Lab 1"),
+        ClassEntry("ENG1004", "Ms. James", "09:00", "09:50", "305"),
+        ClassEntry("CSE1001", "Prof. Rao", "10:00", "10:50", "101"),
+        ClassEntry("CHE1005", "Dr. Verma", "11:00", "11:50", "202")
+    ),
+    "Friday" to listOf(
+        ClassEntry("MAT1002", "Dr. Singh", "08:00", "08:50", "201"),
+        ClassEntry("PHY1003", "Dr. Patel", "09:00", "09:50", "Lab 1"),
+        ClassEntry("ENG1004", "Ms. James", "10:00", "10:50", "305"),
+        ClassEntry("CHE1005", "Dr. Verma", "11:00", "11:50", "202")
+    ),
+    "Saturday" to listOf(
+        ClassEntry("CSE1001", "Prof. Rao", "09:00", "10:30", "101"),
+        ClassEntry("LAB Project", "Staff", "10:45", "12:15", "Innovation Lab")
+    )
+)


### PR DESCRIPTION
## Summary
- add WeeklySchedule and PlannerScreen based on vit-student-app layout
- hook PlannerScreen into navigation

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_685d3ba4f2d8832fa1dbbe256afe1bd6