### PR TITLE
Fix styling for Today's Menu screen

### DIFF
--- a/vit-student-app/src/screens/FoodMenuScreen.tsx
+++ b/vit-student-app/src/screens/FoodMenuScreen.tsx
@@ -210,14 +210,7 @@ export default function FoodMenuScreen() {
                   {
                     translateY: topIconAnim.interpolate({
                       inputRange: [0, 1],
-                      outputRange: [0, -4],
-                    }),
-                  },
-                  {
-                    rotate: topIconAnim.interpolate({
-                      inputRange: [0, 1],
-                      outputRange: ['0deg', '-10deg'],
- 
+                      outputRange: [0, 0], // keep icon vertically aligned
                     }),
                   },
                 ],
@@ -238,7 +231,8 @@ export default function FoodMenuScreen() {
               style={[
                 styles.mealBlock,
                 { backgroundColor: mealColors[idx % mealColors.length] },
-                status.ended && styles.mealBlockEnded,
+                // Keep original card color even after the meal ends
+                // status.ended && styles.mealBlockEnded,
               ]}
             >
               <View style={styles.mealHeader}>
@@ -349,7 +343,7 @@ const styles = StyleSheet.create({
   },
   heading: {
     fontSize: 22,
-    fontWeight: '700',
+    fontWeight: 'bold',
     marginBottom: 4,
     textAlign: 'center',
   },
@@ -376,11 +370,6 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.1,
     shadowRadius: 4,
     elevation: 2,
-  },
-  mealBlockEnded: {
-    // Use a lighter background instead of opacity so the text
-    // label doesn't show a white halo when the card is dimmed.
-    backgroundColor: '#ddd',
   },
   mealHeader: {
     flexDirection: 'row',
@@ -466,13 +455,16 @@ const styles = StyleSheet.create({
   },
   button: {
     marginTop: 20,
-    padding: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
     borderRadius: 8,
-    backgroundColor: '#ccc',
+    backgroundColor: '#007bff',
     alignItems: 'center',
+    flexDirection: 'row',
+    alignSelf: 'center',
   },
   buttonText: {
-    color: '#000',
+    color: '#fff',
     fontWeight: '600',
   },
   message: {


### PR DESCRIPTION
## Summary
- keep meal card colors consistent when ended
- bold "Today's Menu" heading
- align animated restaurant icon with heading
- polish Food Summary button style

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d3fb1c650832f97dc74de494e99f5