### PR TITLE
Fix styling for Today's Menu screen

### DIFF
--- a/app/src/main/java/com/example/basic/FoodMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/FoodMenuScreen.kt
@@ -124,6 +124,7 @@ fun FoodMenuScreen(onShowSummary: () -> Unit, onViewMonth: () -> Unit = {}) {
                 Text(
                     text = "Today's Menu",
                     style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold,
                     modifier = Modifier.alignByBaseline()
                 )
                 Spacer(Modifier.width(8.dp))
@@ -136,7 +137,6 @@ fun FoodMenuScreen(onShowSummary: () -> Unit, onViewMonth: () -> Unit = {}) {
                         .graphicsLayer {
                             scaleX = iconScale
                             scaleY = iconScale
-                            rotationZ = iconRotate
                         }
                         .alignByBaseline()
                 )
@@ -171,8 +171,11 @@ fun FoodMenuScreen(onShowSummary: () -> Unit, onViewMonth: () -> Unit = {}) {
             }
             Button(
                 onClick = onShowSummary,
+                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF007BFF)),
                 modifier = Modifier.align(Alignment.CenterHorizontally)
-            ) { Text("Food Summary") }
+            ) {
+                Text("Food Summary", color = Color.White)
+            }
         }
 
         MonthBar(onClick = onViewMonth, modifier = Modifier.align(Alignment.BottomCenter))
@@ -217,7 +220,7 @@ private fun MealCard(
         else -> "Upcoming"
     }
     val ended = now.after(end.time)
-    val containerColor = if (ended) Color(0xFFDADADA) else background
+    val containerColor = background
     Card(
         shape = RoundedCornerShape(8.dp),
         colors = CardDefaults.cardColors(containerColor = containerColor),

--- a/vit-student-app/src/screens/FoodMenuScreen.tsx
+++ b/vit-student-app/src/screens/FoodMenuScreen.tsx
@@ -201,23 +201,11 @@ export default function FoodMenuScreen() {
                       outputRange: [1, 1.15],
                     }),
                   },
-                  {
-                    rotate: topIconAnim.interpolate({
-                      inputRange: [0, 1],
-                      outputRange: ['0deg', '-10deg'],
-                    }),
-                  },
+                  // keep the icon scale animation but avoid rotation/offset
                   {
                     translateY: topIconAnim.interpolate({
                       inputRange: [0, 1],
-                      outputRange: [0, -4],
-                    }),
-                  },
-                  {
-                    rotate: topIconAnim.interpolate({
-                      inputRange: [0, 1],
-                      outputRange: ['0deg', '-10deg'],
- 
+                      outputRange: [0, 0],
                     }),
                   },
                 ],
@@ -238,7 +226,8 @@ export default function FoodMenuScreen() {
               style={[
                 styles.mealBlock,
                 { backgroundColor: mealColors[idx % mealColors.length] },
-                status.ended && styles.mealBlockEnded,
+                // Keep original card color even after the meal ends
+                // status.ended && styles.mealBlockEnded,
               ]}
             >
               <View style={styles.mealHeader}>
@@ -313,6 +302,7 @@ export default function FoodMenuScreen() {
           );
         })}
         <TouchableOpacity style={styles.button} onPress={showSummary}>
+          <Ionicons name="fast-food" size={16} color="#fff" style={{ marginRight: 6 }} />
           <Text style={styles.buttonText}>Food Summary</Text>
         </TouchableOpacity>
       </ScrollView>
@@ -349,7 +339,7 @@ const styles = StyleSheet.create({
   },
   heading: {
     fontSize: 22,
-    fontWeight: '700',
+    fontWeight: 'bold',
     marginBottom: 4,
     textAlign: 'center',
   },
@@ -376,11 +366,6 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.1,
     shadowRadius: 4,
     elevation: 2,
-  },
-  mealBlockEnded: {
-    // Use a lighter background instead of opacity so the text
-    // label doesn't show a white halo when the card is dimmed.
-    backgroundColor: '#ddd',
   },
   mealHeader: {
     flexDirection: 'row',
@@ -466,13 +451,16 @@ const styles = StyleSheet.create({
   },
   button: {
     marginTop: 20,
-    padding: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
     borderRadius: 8,
-    backgroundColor: '#ccc',
+    backgroundColor: '#007bff',
     alignItems: 'center',
+    flexDirection: 'row',
+    alignSelf: 'center',
   },
   buttonText: {
-    color: '#000',
+    color: '#fff',
     fontWeight: '600',
   },
   message: {


### PR DESCRIPTION
## Summary
- align header icon animation with text
- add small icon to the Food Summary button
- keep original meal card colors after a meal ends
- style heading bold in Android Compose screen
- style Food Summary button in Android screen and keep card colors

## Testing
- `npm test` *(fails: Missing script)*
- `./gradlew test` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_685d3fb1c650832f97dc74de494e99f5