### PR TITLE
Shorten attendance cards

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceScreen.kt
@@ -88,7 +88,8 @@ private fun SubjectCard(item: Subject, isLab: Boolean) {
     Card(
         modifier = Modifier
             .padding(6.dp)
-            .height(130.dp)
+            // Shorten the card height a bit so the boxes take up less space
+            .height(110.dp)
             .graphicsLayer(scaleX = cardScale.value, scaleY = cardScale.value)
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },

--- a/vit-student-app/src/screens/Attendance.tsx
+++ b/vit-student-app/src/screens/Attendance.tsx
@@ -31,7 +31,9 @@ const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const CARD_MARGIN = 12;
  
 const CARD_WIDTH = (SCREEN_WIDTH - CARD_MARGIN * 3) / 2 - 8;
-const CARD_HEIGHT = 130;
+// Slightly reduce the height of each attendance card so they don't appear as
+// tall.
+const CARD_HEIGHT = 110;
  
 
 function getBackgroundColor(p: number): string {


### PR DESCRIPTION
## Summary
- reduce the height of attendance cards in the React Native app
- shrink the attendance boxes in the Jetpack Compose screen

## Testing
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685d447f9628832fae193227ea24eb80