### PR TITLE
Enable swipe in planner

### DIFF
--- a/app/src/main/java/com/example/basic/PlannerScreen.kt
+++ b/app/src/main/java/com/example/basic/PlannerScreen.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -19,17 +21,36 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.pointerInput
 
 @Composable
 fun PlannerScreen() {
     val days = WEEKLY_SCHEDULE.keys.toList()
-    var day by remember { mutableStateOf(days.first()) }
+    var dayIndex by remember { mutableStateOf(0) }
+    val day = days[dayIndex]
     val classes = WEEKLY_SCHEDULE[day].orEmpty()
+    var dragAmount by remember { mutableStateOf(0f) }
 
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(Color(0xFFF0F2F5))
+            .pointerInput(dayIndex) {
+                detectHorizontalDragGestures(
+                    onHorizontalDrag = { _, delta ->
+                        dragAmount += delta
+                    },
+                    onDragEnd = {
+                        if (dragAmount < -100 && dayIndex < days.lastIndex) {
+                            dayIndex++
+                        } else if (dragAmount > 100 && dayIndex > 0) {
+                            dayIndex--
+                        }
+                        dragAmount = 0f
+                    },
+                    onDragCancel = { dragAmount = 0f }
+                )
+            }
     ) {
         Text(
             text = "Weekly Timetable",
@@ -44,8 +65,8 @@ fun PlannerScreen() {
             modifier = Modifier.padding(bottom = 8.dp),
             contentPadding = PaddingValues(horizontal = 16.dp)
         ) {
-            items(days) { d ->
-                val selected = d == day
+            itemsIndexed(days) { i, d ->
+                val selected = i == dayIndex
                 Text(
                     text = d.take(3),
                     fontSize = 14.sp,
@@ -55,7 +76,7 @@ fun PlannerScreen() {
                         .padding(end = 8.dp)
                         .clip(RoundedCornerShape(20.dp))
                         .background(if (selected) Color(0xFF6C5CE7) else Color(0xFFE0E0E0))
-                        .clickable { day = d }
+                        .clickable { dayIndex = i }
                         .padding(horizontal = 12.dp, vertical = 8.dp)
                 )
             }
@@ -70,7 +91,7 @@ fun PlannerScreen() {
                         .fillMaxWidth()
                         .padding(vertical = 6.dp),
                     colors = CardDefaults.cardColors(containerColor = Color.White),
-                    elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
                     shape = RoundedCornerShape(12.dp)
                 ) {
                     Row(

--- a/app/src/main/java/com/example/basic/WeeklySchedule.kt
+++ b/app/src/main/java/com/example/basic/WeeklySchedule.kt
@@ -43,6 +43,7 @@ val WEEKLY_SCHEDULE: Map<String, List<ClassEntry>> = mapOf(
     ),
     "Saturday" to listOf(
         ClassEntry("CSE1001", "Prof. Rao", "09:00", "10:30", "101"),
-        ClassEntry("LAB Project", "Staff", "10:45", "12:15", "Innovation Lab")
+        ClassEntry("LAB Project", "Staff", "10:45", "12:15", "Innovation Lab"),
+        ClassEntry("MAT1002", "Dr. Singh", "12:30", "13:20", "201")
     )
 )

--- a/vit-student-app/src/data/weeklySchedule.ts
+++ b/vit-student-app/src/data/weeklySchedule.ts
@@ -44,6 +44,7 @@ export const WEEKLY_SCHEDULE: WeeklySchedule = {
   Saturday: [
     { course: 'CSE1001', faculty: 'Prof. Rao', start: '09:00', end: '10:30', room: '101' },
     { course: 'LAB Project', faculty: 'Staff', start: '10:45', end: '12:15', room: 'Innovation Lab' },
+    { course: 'MAT1002', faculty: 'Dr. Singh', start: '12:30', end: '13:20', room: '201' },
   ],
 };
 


### PR DESCRIPTION
## Summary
- allow swiping horizontally on planner screen to change days
- bump timetable card elevation for visible shadow
- ensure 3+ entries in planner by extending Saturday schedule
- fix Compose `items` import to resolve build errors

## Testing
- `./gradlew assembleDebug` *(fails: unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685d4388ef84832faf7b7b3e863a0068