### PR TITLE
Add monthly menu screen

### DIFF
--- a/app/src/main/assets/monthly-menu-may-2025.json
+++ b/app/src/main/assets/monthly-menu-may-2025.json
@@ -1,0 +1,1966 @@
+{
+  "2025-06-01": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Aloo Paratha (2)",
+        "Upma",
+        "Lemon Ginger Chutney",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Egg Podimas"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Chicken Dum Biryani (NV) / Paneer Dum Vegetable Biryani (Veg)",
+        "Chicken Gravy / Veg Gravy",
+        "White Rice",
+        "Rasam",
+        "Poori",
+        "Onion Raitha"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Ice Cream Bar or Cup",
+        "Tea",
+        "Coffee"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Bhindi do pyaza gravy",
+        "Sambhar",
+        "White rice",
+        "Fruits",
+        "Coffee Powder",
+        "Milk",
+        "Lemon pickle"
+      ]
+    }
+  ],
+  "2025-06-02": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Idli",
+        "Bhatura",
+        "Pongal",
+        "Ground nut chutney",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Boiled Egg"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Phulka",
+        "Mixed veg",
+        "Kadai veg",
+        "White rice",
+        "Dal",
+        "Rasam",
+        "Mango pickle",
+        "Curd"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Bread toast + Jam",
+        "Banana poriyal",
+        "Buttermilk",
+        "Fryums",
+        "Sweet",
+        "Boondi laddu",
+        "Mango pickle"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Paneer Butter Masala / Chicken Butter Masala",
+        "Dal Tadka",
+        "Rasam",
+        "White Rice",
+        "Curd",
+        "Fruits",
+        "Pickle",
+        "Milk",
+        "Coffee Powder",
+        "Onions"
+      ]
+    }
+  ],
+  "2025-06-03": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Masala Dosa",
+        "Vada Pav",
+        "Coconut Chutney",
+        "Sambar",
+        "Toasted Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Bisibele Bath",
+        "Rajma Masala",
+        "Cabbage beans carrot poriyal",
+        "White rice",
+        "Tomato Rasam",
+        "Buttermilk"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Samosa",
+        "Mushroom biryani",
+        "Veg kurma",
+        "Tomato Egg Curry (NV)",
+        "Rice",
+        "Rasam"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Kadai Paneer",
+        "White Rice",
+        "Radish Kara Curry",
+        "Kolambu",
+        "Curd"
+      ]
+    }
+  ],
+  "2025-06-04": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Set Dosa",
+        "Veg semiya upma",
+        "Sambar",
+        "Chutney",
+        "Brown Bread + Butter + Jam",
+        "Coffee Powder",
+        "Tea",
+        "Milk",
+        "NV - Egg Podimas"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Andhra style chicken fry (NV)",
+        "Veg Chapatha",
+        "White Rice",
+        "Dal",
+        "Onion Raitha"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Aloo bhaji",
+        "Gobi 65"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Lauki Channa Masala",
+        "Masala Dal",
+        "White Rice",
+        "Sambar",
+        "Milk",
+        "Curd",
+        "Coffee Powder",
+        "Fruits"
+      ]
+    }
+  ],
+  "2025-06-05": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Poori",
+        "Potato Masala",
+        "Bhaji",
+        "Semiya Upma",
+        "Coconut Chutney",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Boiled Egg"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Roti",
+        "Aloo Carrot cauliflower gravy",
+        "Amaranthus Dal",
+        "White Rice",
+        "Deep Fry (65 style)",
+        "Rasam"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Banana Bajji"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Dosakaya Pappu",
+        "Dondakaya Curry",
+        "White Rice",
+        "Pickle",
+        "Rasam",
+        "Milk",
+        "Curd",
+        "Coffee Powder",
+        "Fruits"
+      ]
+    }
+  ],
+  "2025-06-06": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Karam podi dosa (3 nos)",
+        "Pav Bhaji",
+        "Coconut Chutney",
+        "Sambar",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Egg Bhurji"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Veg pulao",
+        "Brinjal kara curry",
+        "Sambar",
+        "Dal Maharani",
+        "Beetroot Chana poriyal",
+        "White rice",
+        "Rasam"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Sambar Vada (2 pcs)"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Lacha Paratha (2)",
+        "Veg Shahi Paneer",
+        "Bottle Gourd Kootu",
+        "White Rice",
+        "Curd",
+        "Rasam",
+        "Fruits",
+        "Coffee Powder",
+        "Milk"
+      ]
+    }
+  ],
+  "2025-06-07": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Mysore Bonda (3 pcs)",
+        "Carrot Upma",
+        "Groundnut Chutney",
+        "Sambar",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Omelet"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Dal Punjabi Roti",
+        "Veg Fried Rice",
+        "Gobi Manchurian (3 pcs)",
+        "White Rice",
+        "Sambar",
+        "Pickle",
+        "Milk"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Ginger Tea"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Chukka kura pappu",
+        "Aloo capsicum curry",
+        "Sambhar",
+        "White rice",
+        "Fruits",
+        "Coffee Powder",
+        "Milk",
+        "Lemon pickle"
+      ]
+    }
+  ],
+  "2025-06-08": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Aloo Paratha (2)",
+        "Upma",
+        "Lemon Ginger Chutney",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Egg Podimas"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Chicken Dum Biryani (NV) / Paneer Dum Vegetable Biryani (Veg)",
+        "Chicken Gravy / Veg Gravy",
+        "White Rice",
+        "Rasam",
+        "Poori",
+        "Onion Raitha"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Ice Cream Bar or Cup",
+        "Tea",
+        "Coffee"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Bhindi do pyaza gravy",
+        "Sambhar",
+        "White rice",
+        "Fruits",
+        "Coffee Powder",
+        "Milk",
+        "Lemon pickle"
+      ]
+    }
+  ],
+  "2025-06-09": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Idli",
+        "Bhatura",
+        "Pongal",
+        "Ground nut chutney",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Boiled Egg"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Phulka",
+        "Mixed veg",
+        "Kadai veg",
+        "White rice",
+        "Dal",
+        "Rasam",
+        "Mango pickle",
+        "Curd"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Bread toast + Jam",
+        "Banana poriyal",
+        "Buttermilk",
+        "Fryums",
+        "Sweet",
+        "Boondi laddu",
+        "Mango pickle"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Paneer Butter Masala / Chicken Butter Masala",
+        "Dal Tadka",
+        "Rasam",
+        "White Rice",
+        "Curd",
+        "Fruits",
+        "Pickle",
+        "Milk",
+        "Coffee Powder",
+        "Onions"
+      ]
+    }
+  ],
+  "2025-06-10": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Masala Dosa",
+        "Vada Pav",
+        "Coconut Chutney",
+        "Sambar",
+        "Toasted Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Bisibele Bath",
+        "Rajma Masala",
+        "Cabbage beans carrot poriyal",
+        "White rice",
+        "Tomato Rasam",
+        "Buttermilk"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Samosa",
+        "Mushroom biryani",
+        "Veg kurma",
+        "Tomato Egg Curry (NV)",
+        "Rice",
+        "Rasam"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Kadai Paneer",
+        "White Rice",
+        "Radish Kara Curry",
+        "Kolambu",
+        "Curd"
+      ]
+    }
+  ],
+  "2025-06-11": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Set Dosa",
+        "Veg semiya upma",
+        "Sambar",
+        "Chutney",
+        "Brown Bread + Butter + Jam",
+        "Coffee Powder",
+        "Tea",
+        "Milk",
+        "NV - Egg Podimas"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Andhra style chicken fry (NV)",
+        "Veg Chapatha",
+        "White Rice",
+        "Dal",
+        "Onion Raitha"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Aloo bhaji",
+        "Gobi 65"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Lauki Channa Masala",
+        "Masala Dal",
+        "White Rice",
+        "Sambar",
+        "Milk",
+        "Curd",
+        "Coffee Powder",
+        "Fruits"
+      ]
+    }
+  ],
+  "2025-06-12": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Poori",
+        "Potato Masala",
+        "Bhaji",
+        "Semiya Upma",
+        "Coconut Chutney",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Boiled Egg"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Roti",
+        "Aloo Carrot cauliflower gravy",
+        "Amaranthus Dal",
+        "White Rice",
+        "Deep Fry (65 style)",
+        "Rasam"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Banana Bajji"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Dosakaya Pappu",
+        "Dondakaya Curry",
+        "White Rice",
+        "Pickle",
+        "Rasam",
+        "Milk",
+        "Curd",
+        "Coffee Powder",
+        "Fruits"
+      ]
+    }
+  ],
+  "2025-06-13": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Karam podi dosa (3 nos)",
+        "Pav Bhaji",
+        "Coconut Chutney",
+        "Sambar",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Egg Bhurji"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Veg pulao",
+        "Brinjal kara curry",
+        "Sambar",
+        "Dal Maharani",
+        "Beetroot Chana poriyal",
+        "White rice",
+        "Rasam"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Sambar Vada (2 pcs)"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Lacha Paratha (2)",
+        "Veg Shahi Paneer",
+        "Bottle Gourd Kootu",
+        "White Rice",
+        "Curd",
+        "Rasam",
+        "Fruits",
+        "Coffee Powder",
+        "Milk"
+      ]
+    }
+  ],
+  "2025-06-14": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Mysore Bonda (3 pcs)",
+        "Carrot Upma",
+        "Groundnut Chutney",
+        "Sambar",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Omelet"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Dal Punjabi Roti",
+        "Veg Fried Rice",
+        "Gobi Manchurian (3 pcs)",
+        "White Rice",
+        "Sambar",
+        "Pickle",
+        "Milk"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Ginger Tea"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Chukka kura pappu",
+        "Aloo capsicum curry",
+        "Sambhar",
+        "White rice",
+        "Fruits",
+        "Coffee Powder",
+        "Milk",
+        "Lemon pickle"
+      ]
+    }
+  ],
+  "2025-06-15": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Aloo Paratha (2)",
+        "Upma",
+        "Lemon Ginger Chutney",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Egg Podimas"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Chicken Dum Biryani (NV) / Paneer Dum Vegetable Biryani (Veg)",
+        "Chicken Gravy / Veg Gravy",
+        "White Rice",
+        "Rasam",
+        "Poori",
+        "Onion Raitha"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Ice Cream Bar or Cup",
+        "Tea",
+        "Coffee"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Bhindi do pyaza gravy",
+        "Sambhar",
+        "White rice",
+        "Fruits",
+        "Coffee Powder",
+        "Milk",
+        "Lemon pickle"
+      ]
+    }
+  ],
+  "2025-06-16": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Idli",
+        "Bhatura",
+        "Pongal",
+        "Ground nut chutney",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Boiled Egg"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Phulka",
+        "Mixed veg",
+        "Kadai veg",
+        "White rice",
+        "Dal",
+        "Rasam",
+        "Mango pickle",
+        "Curd"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Bread toast + Jam",
+        "Banana poriyal",
+        "Buttermilk",
+        "Fryums",
+        "Sweet",
+        "Boondi laddu",
+        "Mango pickle"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Paneer Butter Masala / Chicken Butter Masala",
+        "Dal Tadka",
+        "Rasam",
+        "White Rice",
+        "Curd",
+        "Fruits",
+        "Pickle",
+        "Milk",
+        "Coffee Powder",
+        "Onions"
+      ]
+    }
+  ],
+  "2025-06-17": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Masala Dosa",
+        "Vada Pav",
+        "Coconut Chutney",
+        "Sambar",
+        "Toasted Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Bisibele Bath",
+        "Rajma Masala",
+        "Cabbage beans carrot poriyal",
+        "White rice",
+        "Tomato Rasam",
+        "Buttermilk"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Samosa",
+        "Mushroom biryani",
+        "Veg kurma",
+        "Tomato Egg Curry (NV)",
+        "Rice",
+        "Rasam"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Kadai Paneer",
+        "White Rice",
+        "Radish Kara Curry",
+        "Kolambu",
+        "Curd"
+      ]
+    }
+  ],
+  "2025-06-18": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Set Dosa",
+        "Veg semiya upma",
+        "Sambar",
+        "Chutney",
+        "Brown Bread + Butter + Jam",
+        "Coffee Powder",
+        "Tea",
+        "Milk",
+        "NV - Egg Podimas"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Andhra style chicken fry (NV)",
+        "Veg Chapatha",
+        "White Rice",
+        "Dal",
+        "Onion Raitha"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Aloo bhaji",
+        "Gobi 65"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Lauki Channa Masala",
+        "Masala Dal",
+        "White Rice",
+        "Sambar",
+        "Milk",
+        "Curd",
+        "Coffee Powder",
+        "Fruits"
+      ]
+    }
+  ],
+  "2025-06-19": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Poori",
+        "Potato Masala",
+        "Bhaji",
+        "Semiya Upma",
+        "Coconut Chutney",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Boiled Egg"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Roti",
+        "Aloo Carrot cauliflower gravy",
+        "Amaranthus Dal",
+        "White Rice",
+        "Deep Fry (65 style)",
+        "Rasam"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Banana Bajji"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Dosakaya Pappu",
+        "Dondakaya Curry",
+        "White Rice",
+        "Pickle",
+        "Rasam",
+        "Milk",
+        "Curd",
+        "Coffee Powder",
+        "Fruits"
+      ]
+    }
+  ],
+  "2025-06-20": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Karam podi dosa (3 nos)",
+        "Pav Bhaji",
+        "Coconut Chutney",
+        "Sambar",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Egg Bhurji"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Veg pulao",
+        "Brinjal kara curry",
+        "Sambar",
+        "Dal Maharani",
+        "Beetroot Chana poriyal",
+        "White rice",
+        "Rasam"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Sambar Vada (2 pcs)"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Lacha Paratha (2)",
+        "Veg Shahi Paneer",
+        "Bottle Gourd Kootu",
+        "White Rice",
+        "Curd",
+        "Rasam",
+        "Fruits",
+        "Coffee Powder",
+        "Milk"
+      ]
+    }
+  ],
+  "2025-06-21": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Mysore Bonda (3 pcs)",
+        "Carrot Upma",
+        "Groundnut Chutney",
+        "Sambar",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Omelet"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Dal Punjabi Roti",
+        "Veg Fried Rice",
+        "Gobi Manchurian (3 pcs)",
+        "White Rice",
+        "Sambar",
+        "Pickle",
+        "Milk"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Ginger Tea"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Chukka kura pappu",
+        "Aloo capsicum curry",
+        "Sambhar",
+        "White rice",
+        "Fruits",
+        "Coffee Powder",
+        "Milk",
+        "Lemon pickle"
+      ]
+    }
+  ],
+  "2025-06-22": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Aloo Paratha (2)",
+        "Upma",
+        "Lemon Ginger Chutney",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Egg Podimas"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Chicken Dum Biryani (NV) / Paneer Dum Vegetable Biryani (Veg)",
+        "Chicken Gravy / Veg Gravy",
+        "White Rice",
+        "Rasam",
+        "Poori",
+        "Onion Raitha"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Ice Cream Bar or Cup",
+        "Tea",
+        "Coffee"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Bhindi do pyaza gravy",
+        "Sambhar",
+        "White rice",
+        "Fruits",
+        "Coffee Powder",
+        "Milk",
+        "Lemon pickle"
+      ]
+    }
+  ],
+  "2025-06-23": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Idli",
+        "Bhatura",
+        "Pongal",
+        "Ground nut chutney",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Boiled Egg"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Phulka",
+        "Mixed veg",
+        "Kadai veg",
+        "White rice",
+        "Dal",
+        "Rasam",
+        "Mango pickle",
+        "Curd"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Bread toast + Jam",
+        "Banana poriyal",
+        "Buttermilk",
+        "Fryums",
+        "Sweet",
+        "Boondi laddu",
+        "Mango pickle"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Paneer Butter Masala / Chicken Butter Masala",
+        "Dal Tadka",
+        "Rasam",
+        "White Rice",
+        "Curd",
+        "Fruits",
+        "Pickle",
+        "Milk",
+        "Coffee Powder",
+        "Onions"
+      ]
+    }
+  ],
+  "2025-06-24": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Masala Dosa",
+        "Vada Pav",
+        "Coconut Chutney",
+        "Sambar",
+        "Toasted Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Bisibele Bath",
+        "Rajma Masala",
+        "Cabbage beans carrot poriyal",
+        "White rice",
+        "Tomato Rasam",
+        "Buttermilk"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Samosa",
+        "Mushroom biryani",
+        "Veg kurma",
+        "Tomato Egg Curry (NV)",
+        "Rice",
+        "Rasam"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Kadai Paneer",
+        "White Rice",
+        "Radish Kara Curry",
+        "Kolambu",
+        "Curd"
+      ]
+    }
+  ],
+  "2025-06-25": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Set Dosa",
+        "Veg semiya upma",
+        "Sambar",
+        "Chutney",
+        "Brown Bread + Butter + Jam",
+        "Coffee Powder",
+        "Tea",
+        "Milk",
+        "NV - Egg Podimas"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Andhra style chicken fry (NV)",
+        "Veg Chapatha",
+        "White Rice",
+        "Dal",
+        "Onion Raitha"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Aloo bhaji",
+        "Gobi 65"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Lauki Channa Masala",
+        "Masala Dal",
+        "White Rice",
+        "Sambar",
+        "Milk",
+        "Curd",
+        "Coffee Powder",
+        "Fruits"
+      ]
+    }
+  ],
+  "2025-06-26": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Poori",
+        "Potato Masala",
+        "Bhaji",
+        "Semiya Upma",
+        "Coconut Chutney",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Boiled Egg"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Roti",
+        "Aloo Carrot cauliflower gravy",
+        "Amaranthus Dal",
+        "White Rice",
+        "Deep Fry (65 style)",
+        "Rasam"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Banana Bajji"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Dosakaya Pappu",
+        "Dondakaya Curry",
+        "White Rice",
+        "Pickle",
+        "Rasam",
+        "Milk",
+        "Curd",
+        "Coffee Powder",
+        "Fruits"
+      ]
+    }
+  ],
+  "2025-06-27": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Karam podi dosa (3 nos)",
+        "Pav Bhaji",
+        "Coconut Chutney",
+        "Sambar",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Egg Bhurji"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Veg pulao",
+        "Brinjal kara curry",
+        "Sambar",
+        "Dal Maharani",
+        "Beetroot Chana poriyal",
+        "White rice",
+        "Rasam"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Sambar Vada (2 pcs)"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Lacha Paratha (2)",
+        "Veg Shahi Paneer",
+        "Bottle Gourd Kootu",
+        "White Rice",
+        "Curd",
+        "Rasam",
+        "Fruits",
+        "Coffee Powder",
+        "Milk"
+      ]
+    }
+  ],
+  "2025-06-28": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Mysore Bonda (3 pcs)",
+        "Carrot Upma",
+        "Groundnut Chutney",
+        "Sambar",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Omelet"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Dal Punjabi Roti",
+        "Veg Fried Rice",
+        "Gobi Manchurian (3 pcs)",
+        "White Rice",
+        "Sambar",
+        "Pickle",
+        "Milk"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Ginger Tea"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Chukka kura pappu",
+        "Aloo capsicum curry",
+        "Sambhar",
+        "White rice",
+        "Fruits",
+        "Coffee Powder",
+        "Milk",
+        "Lemon pickle"
+      ]
+    }
+  ],
+  "2025-06-29": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Aloo Paratha (2)",
+        "Upma",
+        "Lemon Ginger Chutney",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Egg Podimas"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Chicken Dum Biryani (NV) / Paneer Dum Vegetable Biryani (Veg)",
+        "Chicken Gravy / Veg Gravy",
+        "White Rice",
+        "Rasam",
+        "Poori",
+        "Onion Raitha"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Ice Cream Bar or Cup",
+        "Tea",
+        "Coffee"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Bhindi do pyaza gravy",
+        "Sambhar",
+        "White rice",
+        "Fruits",
+        "Coffee Powder",
+        "Milk",
+        "Lemon pickle"
+      ]
+    }
+  ],
+  "2025-06-30": [
+    {
+      "name": "Breakfast",
+      "startHour": 7,
+      "startMinute": 0,
+      "endHour": 8,
+      "endMinute": 30,
+      "items": [
+        "Idli",
+        "Bhatura",
+        "Pongal",
+        "Ground nut chutney",
+        "Bread + Butter + Jam",
+        "Tea",
+        "Coffee Powder",
+        "Milk",
+        "NV - Boiled Egg"
+      ]
+    },
+    {
+      "name": "Lunch",
+      "startHour": 12,
+      "startMinute": 0,
+      "endHour": 14,
+      "endMinute": 30,
+      "items": [
+        "Phulka",
+        "Mixed veg",
+        "Kadai veg",
+        "White rice",
+        "Dal",
+        "Rasam",
+        "Mango pickle",
+        "Curd"
+      ]
+    },
+    {
+      "name": "Snacks",
+      "startHour": 16,
+      "startMinute": 0,
+      "endHour": 17,
+      "endMinute": 30,
+      "items": [
+        "Bread toast + Jam",
+        "Banana poriyal",
+        "Buttermilk",
+        "Fryums",
+        "Sweet",
+        "Boondi laddu",
+        "Mango pickle"
+      ]
+    },
+    {
+      "name": "Dinner",
+      "startHour": 19,
+      "startMinute": 0,
+      "endHour": 21,
+      "endMinute": 30,
+      "items": [
+        "Chapathi",
+        "Paneer Butter Masala / Chicken Butter Masala",
+        "Dal Tadka",
+        "Rasam",
+        "White Rice",
+        "Curd",
+        "Fruits",
+        "Pickle",
+        "Milk",
+        "Coffee Powder",
+        "Onions"
+      ]
+    }
+  ]
+}

--- a/app/src/main/java/com/example/basic/FoodMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/FoodMenuScreen.kt
@@ -41,15 +41,6 @@ import java.util.*
  * Simplified food menu screen inspired by the vit-student-app implementation.
  */
 
-data class Meal(
-    val name: String,
-    val startHour: Int,
-    val startMinute: Int,
-    val endHour: Int,
-    val endMinute: Int,
-    val items: List<String>
-)
-
 private val sampleMenu = listOf(
     Meal(
         "Breakfast",

--- a/app/src/main/java/com/example/basic/MainActivity.kt
+++ b/app/src/main/java/com/example/basic/MainActivity.kt
@@ -64,7 +64,7 @@ fun BasicApp() {
         NavItem(R.string.more, Icons.Filled.MoreHoriz, Icons.Outlined.MoreHoriz)
     )
     var selectedIndex by remember { mutableIntStateOf(0) }
-    var foodScreen by remember { mutableStateOf(0) } // 0 - menu, 1 - summary
+    var foodScreen by remember { mutableStateOf(0) } // 0 - menu, 1 - summary, 2 - monthly
 
     MaterialTheme {
         Scaffold(
@@ -96,10 +96,13 @@ fun BasicApp() {
                     1 -> PlannerScreen()
                     2 -> AttendanceScreen()
                     3 -> {
-                        if (foodScreen == 0) {
-                            FoodMenuScreen(onShowSummary = { foodScreen = 1 })
-                        } else {
-                            FoodSummaryScreen(onBack = { foodScreen = 0 })
+                        when (foodScreen) {
+                            0 -> FoodMenuScreen(
+                                onShowSummary = { foodScreen = 1 },
+                                onViewMonth = { foodScreen = 2 }
+                            )
+                            1 -> FoodSummaryScreen(onBack = { foodScreen = 0 })
+                            else -> MonthlyMenuScreen(onBack = { foodScreen = 0 })
                         }
                     }
                     else -> Text(text = stringResource(id = items[selectedIndex].labelRes))

--- a/app/src/main/java/com/example/basic/Meal.kt
+++ b/app/src/main/java/com/example/basic/Meal.kt
@@ -1,0 +1,10 @@
+package com.example.basic
+
+data class Meal(
+    val name: String,
+    val startHour: Int,
+    val startMinute: Int,
+    val endHour: Int,
+    val endMinute: Int,
+    val items: List<String>
+)

--- a/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
@@ -1,0 +1,204 @@
+package com.example.basic
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.draw.alpha
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.IconButton
+import org.json.JSONObject
+import java.text.SimpleDateFormat
+import java.util.*
+
+private data class DayMeals(val date: String, val meals: List<Meal>)
+
+@Composable
+fun MonthlyMenuScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val menu = remember { loadMenu(context) }
+    var likes by remember { mutableStateOf(setOf<String>()) }
+    val weeks = remember(menu) { toWeeks(menu) }
+    val today = remember { SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date()) }
+
+    Scaffold(
+        topBar = {
+            SmallTopAppBar(
+                title = { Text("Monthly Menu") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        LazyColumn(
+            contentPadding = innerPadding,
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color(0xFFF2F2F2))
+        ) {
+            weeks.forEachIndexed { index, week ->
+                item {
+                    WeekHeader(
+                        title = "Week ${index + 1}",
+                        color = weekColors[index % weekColors.size]
+                    )
+                }
+                itemsIndexed(week) { i, day ->
+                    DayBlock(
+                        day = day,
+                        isPast = day.date < today,
+                        isFirst = i == 0,
+                        isLast = i == week.lastIndex,
+                        dayColor = dayColors[index % dayColors.size],
+                        liked = likes,
+                        toggleLike = { key ->
+                            likes = if (likes.contains(key)) likes - key else likes + key
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun loadMenu(context: Context): Map<String, List<Meal>> {
+    val text = context.assets.open("monthly-menu-may-2025.json").bufferedReader().use { it.readText() }
+    val obj = JSONObject(text)
+    val map = mutableMapOf<String, List<Meal>>()
+    val dates = obj.keys().asSequence().toList().sorted()
+    for (d in dates) {
+        val arr = obj.getJSONArray(d)
+        val meals = mutableListOf<Meal>()
+        for (i in 0 until arr.length()) {
+            val m = arr.getJSONObject(i)
+            val itemsArr = m.getJSONArray("items")
+            val items = List(itemsArr.length()) { itemsArr.getString(it) }
+            meals.add(
+                Meal(
+                    name = m.getString("name"),
+                    startHour = m.getInt("startHour"),
+                    startMinute = m.getInt("startMinute"),
+                    endHour = m.getInt("endHour"),
+                    endMinute = m.getInt("endMinute"),
+                    items = items
+                )
+            )
+        }
+        map[d] = meals
+    }
+    return map
+}
+
+private fun toWeeks(menu: Map<String, List<Meal>>): List<List<DayMeals>> {
+    val dates = menu.keys.sorted()
+    val list = dates.map { DayMeals(it, menu[it]!!) }
+    return list.chunked(7)
+}
+
+private val weekColors = listOf(
+    Color(0xFFF0E4D7),
+    Color(0xFFE7F0D7),
+    Color(0xFFD7E8F0),
+    Color(0xFFF0D7E8)
+)
+
+private val dayColors = listOf(
+    Color(0xFFE5D7CB),
+    Color(0xFFDCE5CB),
+    Color(0xFFCBDCE5),
+    Color(0xFFE5CBDC)
+)
+
+@Composable
+private fun WeekHeader(title: String, color: Color) {
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp, vertical = 4.dp)
+            .background(color, RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)),
+        contentAlignment = Alignment.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .background(Color.Black, RoundedCornerShape(20.dp))
+                .padding(horizontal = 12.dp, vertical = 4.dp)
+        ) {
+            Text(title, color = Color.White, fontWeight = FontWeight.SemiBold)
+        }
+    }
+}
+
+@Composable
+private fun DayBlock(
+    day: DayMeals,
+    isPast: Boolean,
+    isFirst: Boolean,
+    isLast: Boolean,
+    dayColor: Color,
+    liked: Set<String>,
+    toggleLike: (String) -> Unit
+) {
+    val shape = RoundedCornerShape(
+        topStart = if (isFirst) 12.dp else 0.dp,
+        topEnd = if (isFirst) 12.dp else 0.dp,
+        bottomStart = if (isLast) 12.dp else 0.dp,
+        bottomEnd = if (isLast) 12.dp else 0.dp
+    )
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp)
+            .background(dayColor, shape)
+            .then(if (isPast) Modifier.alpha(0.5f) else Modifier)
+            .padding(12.dp)
+    ) {
+        Surface(
+            color = Color(0xFFC0C0C0),
+            shape = RoundedCornerShape(20.dp),
+            modifier = Modifier.padding(bottom = 6.dp)
+        ) {
+            Text(
+                text = day.date,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+        day.meals.forEach { m ->
+            val key = "${day.date}-${m.name}"
+            Column(modifier = Modifier.padding(bottom = 8.dp)) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(m.name, fontWeight = FontWeight.SemiBold)
+                    IconButton(onClick = { toggleLike(key) }, modifier = Modifier.size(16.dp)) {
+                        Icon(
+                            imageVector = if (liked.contains(key)) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                            contentDescription = null,
+                            tint = if (liked.contains(key)) Color.Red else Color.Black,
+                            modifier = Modifier.size(16.dp)
+                        )
+                    }
+                }
+                Text(m.items.joinToString(", "), color = Color(0xFF555555))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `MonthlyMenuScreen` mirroring TypeScript monthly view
- share `Meal` model across screens
- wire up `MonthlyMenuScreen` from `FoodMenuScreen`
- copy monthly menu data to Android assets

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685d43db719c832f8261a4f7765d59a7