### PR TITLE
Shorten attendance cards

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceScreen.kt
@@ -88,7 +88,8 @@ private fun SubjectCard(item: Subject, isLab: Boolean) {
     Card(
         modifier = Modifier
             .padding(6.dp)
-            .height(130.dp)
+            // Shorten the card height a bit so the boxes take up less space
+            .height(110.dp)
             .graphicsLayer(scaleX = cardScale.value, scaleY = cardScale.value)
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
@@ -106,13 +107,15 @@ private fun SubjectCard(item: Subject, isLab: Boolean) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(8.dp)
+                // use a bit less vertical padding so the header has more room
+                .padding(horizontal = 8.dp, vertical = 4.dp)
         ) {
-            Column(modifier = Modifier.weight(0.4f)) {
+            // give the header a little more space to avoid clipping the code
+            Column(modifier = Modifier.weight(0.45f)) {
                 Text(text = item.name, fontSize = 18.sp, fontWeight = FontWeight.SemiBold, color = Color(0xFF212121))
                 Text(text = item.code, fontSize = 14.sp, color = Color(0xFF212121))
             }
-            Spacer(modifier = Modifier.weight(0.1f))
+            Spacer(modifier = Modifier.weight(0.05f))
             Row(
                 modifier = Modifier
                     .weight(0.5f)

--- a/vit-student-app/src/screens/Attendance.tsx
+++ b/vit-student-app/src/screens/Attendance.tsx
@@ -31,7 +31,9 @@ const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const CARD_MARGIN = 12;
  
 const CARD_WIDTH = (SCREEN_WIDTH - CARD_MARGIN * 3) / 2 - 8;
-const CARD_HEIGHT = 130;
+// Slightly reduce the height of each attendance card so they don't appear as
+// tall.
+const CARD_HEIGHT = 110;
  
 
 function getBackgroundColor(p: number): string {
@@ -163,10 +165,13 @@ const styles = StyleSheet.create({
     opacity: 0.8,
   },
   header: {
-    flex: 0.4,
+    // slightly increase the flex and reduce top padding so the course code
+    // text isn't clipped when the card height is shortened
+    flex: 0.45,
     justifyContent: 'center',
     paddingHorizontal: 8,
-    paddingTop: 12,
+    paddingTop: 8,
+    paddingBottom: 4,
   },
   subject: {
     fontSize: 18,


### PR DESCRIPTION
## Summary
- reduce vertical padding and adjust weights in Jetpack Compose attendance cards so the course code is fully visible
- tweak header flex and padding in React Native attendance cards to avoid clipping

## Testing
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685d447f9628832fae193227ea24eb80