### PR TITLE
Adjust home card layout and animation

### DIFF
--- a/vit-student-app/src/components/Card.tsx
+++ b/vit-student-app/src/components/Card.tsx
@@ -23,7 +23,7 @@ import useWeather from '../hooks/useWeather';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 export const CARD_WIDTH = SCREEN_WIDTH * 0.85;
-export const CARD_HEIGHT = SCREEN_HEIGHT * 0.60;
+export const CARD_HEIGHT = SCREEN_HEIGHT * 0.75;
 
 /** Number of raindrops */
 const RAINDROP_COUNT = 12;
@@ -315,7 +315,7 @@ function Raindrops() {
       anim: new Animated.Value(-Math.random() * CARD_HEIGHT),
       xPos: Math.random() * (CARD_WIDTH - 2) + 1,
       delay: Math.random() * 2000,
-      speed: 1800 + Math.random() * 800,
+      speed: 6000 + Math.random() * 4000,
     }))
   ).current;
 
@@ -331,7 +331,7 @@ function Raindrops() {
           useNativeDriver: true,
         }).start(({ finished }) => {
           if (finished) {
-            const newSpeed = 1800 + Math.random() * 800;
+            const newSpeed = 6000 + Math.random() * 4000;
             const newDelay = Math.random() * 1200;
             anim.setValue(-20);
             Animated.timing(anim, {
@@ -490,6 +490,7 @@ const styles = StyleSheet.create({
   contentContainer: {
     flex: 1,
     justifyContent: 'center',
+    alignItems: 'flex-start',
     paddingHorizontal: 24,
     zIndex: 3,
   },

--- a/vit-student-app/src/screens/Home.tsx
+++ b/vit-student-app/src/screens/Home.tsx
@@ -174,6 +174,7 @@ const styles = StyleSheet.create({
   },
   carouselRegion: {
     flex: 1,
+    alignItems: 'center',
   },
   overlay: {
     ...StyleSheet.absoluteFillObject,


### PR DESCRIPTION
## Summary
- center carousel container on Home page
- increase card height
- slow down raindrop animation
- left-align card text

## Testing
- `./gradlew test` *(fails: unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685d588c8c1c832fa4117938bcfb9cc9