### PR TITLE
Adjust home card layout and animation

### DIFF
--- a/app/src/main/java/com/example/basic/ClassCard.kt
+++ b/app/src/main/java/com/example/basic/ClassCard.kt
@@ -53,7 +53,7 @@ fun ClassCard(
     val wPx = with(density) { config.screenWidthDp.dp.toPx() }
     val hPx = with(density) { config.screenHeightDp.dp.toPx() }
     val cardW = wPx * 0.85f
-    val cardH = hPx * 0.60f
+    val cardH = hPx * 0.75f
     val cardWidth = with(density) { cardW.toDp() }
     val cardHeight = with(density) { cardH.toDp() }
 
@@ -148,7 +148,7 @@ fun ClassCard(
 
             Column(
                 modifier = Modifier
-                    .align(Alignment.Center)
+                    .align(Alignment.CenterStart)
                     .padding(horizontal = 24.dp),
                 horizontalAlignment = Alignment.Start
             ) {
@@ -301,7 +301,7 @@ private fun Raindrops(cardWidth: Dp, cardHeight: Dp) {
                 state.value.anim.animateTo(
                     targetValue = heightPx + 20f,
                     animationSpec = tween(
-                        durationMillis = (4000 + Random.nextInt(2000)),
+                        durationMillis = (6000 + Random.nextInt(4000)),
                         easing = LinearEasing,
                         delayMillis = Random.nextInt(0, 1200)
                     )

--- a/app/src/main/java/com/example/basic/HomeScreen.kt
+++ b/app/src/main/java/com/example/basic/HomeScreen.kt
@@ -69,15 +69,20 @@ fun HomeScreen() {
                         )
                     }
             ) { page ->
-                if (page == 0) {
-                    SummaryCard()
-                } else {
-                    ClassCard(
-                        info = baseCards[page - 1],
-                        index = page - 1,
-                        daySchedule = baseCards,
-                        locationName = "Amaravati"
-                    )
+                Box(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (page == 0) {
+                        SummaryCard()
+                    } else {
+                        ClassCard(
+                            info = baseCards[page - 1],
+                            index = page - 1,
+                            daySchedule = baseCards,
+                            locationName = "Amaravati"
+                        )
+                    }
                 }
             }
 

--- a/vit-student-app/src/components/Card.tsx
+++ b/vit-student-app/src/components/Card.tsx
@@ -23,7 +23,7 @@ import useWeather from '../hooks/useWeather';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 export const CARD_WIDTH = SCREEN_WIDTH * 0.85;
-export const CARD_HEIGHT = SCREEN_HEIGHT * 0.60;
+export const CARD_HEIGHT = SCREEN_HEIGHT * 0.75;
 
 /** Number of raindrops */
 const RAINDROP_COUNT = 12;
@@ -315,7 +315,7 @@ function Raindrops() {
       anim: new Animated.Value(-Math.random() * CARD_HEIGHT),
       xPos: Math.random() * (CARD_WIDTH - 2) + 1,
       delay: Math.random() * 2000,
-      speed: 1800 + Math.random() * 800,
+      speed: 6000 + Math.random() * 4000,
     }))
   ).current;
 
@@ -331,7 +331,7 @@ function Raindrops() {
           useNativeDriver: true,
         }).start(({ finished }) => {
           if (finished) {
-            const newSpeed = 1800 + Math.random() * 800;
+            const newSpeed = 6000 + Math.random() * 4000;
             const newDelay = Math.random() * 1200;
             anim.setValue(-20);
             Animated.timing(anim, {
@@ -490,6 +490,7 @@ const styles = StyleSheet.create({
   contentContainer: {
     flex: 1,
     justifyContent: 'center',
+    alignItems: 'flex-start',
     paddingHorizontal: 24,
     zIndex: 3,
   },

--- a/vit-student-app/src/screens/Home.tsx
+++ b/vit-student-app/src/screens/Home.tsx
@@ -174,6 +174,7 @@ const styles = StyleSheet.create({
   },
   carouselRegion: {
     flex: 1,
+    alignItems: 'center',
   },
   overlay: {
     ...StyleSheet.absoluteFillObject,


### PR DESCRIPTION
## Summary
- center pager cards horizontally
- set card height to occupy 75% of screen
- slow Kotlin raindrop animation to 6–10 seconds
- left-align card body

## Testing
- `./gradlew test` *(fails: unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685d588c8c1c832fa4117938bcfb9cc9