### PR TITLE
Implement sticky week headers

### DIFF
--- a/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
@@ -118,8 +118,12 @@ fun MonthlyMenuScreen(onBack: () -> Unit) {
     ) { padding ->
         LazyColumn(modifier = Modifier.padding(padding)) {
             weeks.forEach { week ->
-                item {
-                    WeekHeader(title = week.title, color = week.color, dayColor = week.dayColor)
+                stickyHeader {
+                    WeekHeader(
+                        title = week.title,
+                        color = week.color,
+                        dayColor = week.dayColor,
+                    )
                 }
                 items(week.days) { day ->
                     DayBlock(
@@ -144,6 +148,7 @@ private fun WeekHeader(title: String, color: Color, dayColor: Color) {
             .fillMaxWidth()
             .background(color)
             .padding(8.dp)
+            .animateItemPlacement()
     ) {
         Box(
             modifier = Modifier

--- a/vit-student-app/src/screens/MonthlyMenuScreen.tsx
+++ b/vit-student-app/src/screens/MonthlyMenuScreen.tsx
@@ -202,7 +202,7 @@ export default function MonthlyMenuScreen() {
         )}
         onScrollToIndexFailed={handleScrollToIndexFailed}
         SectionSeparatorComponent={() => <View style={{ height: 12 }} />}
-        stickySectionHeadersEnabled={false}
+        stickySectionHeadersEnabled
         contentContainerStyle={styles.listContent}
       />
     </SafeAreaView>


### PR DESCRIPTION
## Summary
- float week headers for Compose `MonthlyMenuScreen` using `stickyHeader`
- add `animateItemPlacement` to animate header transitions
- enable sticky headers in React Native `MonthlyMenuScreen`

## Testing
- `./gradlew test` *(fails: Unable to access jarfile gradle-wrapper.jar)*
- `npm test` in `vit-student-app` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685d5b8da9fc832f8c404d737e2735db