### PR TITLE
Add CardCarousel for Kotlin app

### DIFF
--- a/app/src/main/java/com/example/basic/CardCarousel.kt
+++ b/app/src/main/java/com/example/basic/CardCarousel.kt
@@ -1,0 +1,140 @@
+package com.example.basic
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.foundation.shape.CircleShape
+import kotlinx.coroutines.launch
+import kotlin.math.abs
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun CardCarousel(
+    cards: List<ClassInfo>,
+    onSwipeDown: () -> Unit,
+    onSwipeUp: () -> Unit,
+    onIndexChange: ((Int) -> Unit)? = null,
+    locationName: String,
+    modifier: Modifier = Modifier
+) {
+    val pagerState = rememberPagerState(pageCount = { cards.size })
+    val scope = rememberCoroutineScope()
+    var dragAmount by remember { mutableStateOf(0f) }
+
+    LaunchedEffect(pagerState.currentPage) {
+        onIndexChange?.invoke(pagerState.currentPage)
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .pointerInput(Unit) {
+                detectDragGestures(
+                    onDrag = { _, drag ->
+                        dragAmount += drag.y
+                    },
+                    onDragEnd = {
+                        if (dragAmount > 40f) onSwipeDown() else if (dragAmount < -40f) onSwipeUp()
+                        dragAmount = 0f
+                    }
+                )
+            }
+    ) {
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.fillMaxSize()
+        ) { page ->
+            if (page == 0) {
+                SummaryCard()
+            } else {
+                ClassCard(
+                    info = cards[page],
+                    index = page - 1,
+                    daySchedule = cards.drop(1),
+                    locationName = locationName
+                )
+            }
+        }
+
+        if (pagerState.currentPage > 0) {
+            NumberRowAnimated(
+                count = cards.size - 1,
+                currentPage = pagerState.currentPage - 1,
+                pageOffset = pagerState.currentPageOffsetFraction,
+                onTap = { idx -> scope.launch { pagerState.animateScrollToPage(idx + 1) } },
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = 16.dp)
+            )
+
+            Text(
+                text = "Swipe left/right to see all classes",
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 16.dp),
+                color = Color(0xFF555555),
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+    }
+}
+
+@Composable
+private fun NumberRowAnimated(
+    count: Int,
+    currentPage: Int,
+    pageOffset: Float,
+    onTap: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val spacing = 32.dp
+    val circleSize = 16.dp
+    Row(
+        modifier = modifier
+            .height(circleSize * 1.5f),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        repeat(count) { idx ->
+            val pagePos = currentPage + pageOffset
+            val distance = abs(pagePos - idx)
+            val scaleNum = 1f + 0.3f * (1f - distance.coerceIn(0f, 1f))
+            val scaleCircle = 1f + 0.5f * (1f - distance.coerceIn(0f, 1f))
+            val animNum by animateFloatAsState(targetValue = scaleNum)
+            val animCircle by animateFloatAsState(targetValue = scaleCircle)
+            Box(
+                modifier = Modifier
+                    .width(spacing)
+                    .clickable { onTap(idx) },
+                contentAlignment = Alignment.Center
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(circleSize)
+                        .graphicsLayer(scaleX = animCircle, scaleY = animCircle)
+                        .background(Color(0xFF333333), CircleShape)
+                )
+                Text(
+                    text = "${idx + 1}",
+                    color = Color.White,
+                    style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.SemiBold),
+                    modifier = Modifier.graphicsLayer(scaleX = animNum, scaleY = animNum)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/basic/HomeScreen.kt
+++ b/app/src/main/java/com/example/basic/HomeScreen.kt
@@ -4,27 +4,20 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.input.pointer.pointerInput
 import kotlinx.coroutines.launch
 
 enum class PanelState { None, Top, Bottom }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun HomeScreen() {
     val baseCards = listOf(
@@ -35,60 +28,25 @@ fun HomeScreen() {
         ClassInfo("5", "CSE1005 @ Room 201", "12:00 – 12:50"),
     )
     val cards = listOf(ClassInfo("overview", "", "")) + baseCards
-    val pagerState = rememberPagerState(pageCount = { cards.size })
     var panel by remember { mutableStateOf(PanelState.None) }
-    val scope = rememberCoroutineScope()
-    var dragAmount by remember { mutableStateOf(0f) }
 
     Box(
         modifier = Modifier
             .fillMaxSize()
             .background(Color(0xFFF0F0F0))
     ) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            HorizontalPager(
-                state = pagerState,
-                modifier = Modifier
-                    .weight(1f)
-                    .pointerInput(panel) {
-                        detectDragGestures(
-                            onDragEnd = {
-                                if (panel == PanelState.None) {
-                                    if (dragAmount > 40f) panel = PanelState.Top
-                                    else if (dragAmount < -40f) panel = PanelState.Bottom
-                                } else if (panel == PanelState.Top && dragAmount < -40f) {
-                                    panel = PanelState.None
-                                } else if (panel == PanelState.Bottom && dragAmount > 40f) {
-                                    panel = PanelState.None
-                                }
-                                dragAmount = 0f
-                            },
-                            onDrag = { _, drag ->
-                                dragAmount += drag.y
-                            }
-                        )
-                    }
-            ) { page ->
-                if (page == 0) {
-                    SummaryCard()
-                } else {
-                    ClassCard(
-                        info = baseCards[page - 1],
-                        index = page - 1,
-                        daySchedule = baseCards,
-                        locationName = "Amaravati"
-                    )
-                }
-            }
-
-            if (pagerState.currentPage > 0) {
-                NumberRow(
-                    count = baseCards.size,
-                    activeIndex = pagerState.currentPage - 1,
-                    onTap = { idx -> scope.launch { pagerState.animateScrollToPage(idx + 1) } }
-                )
-            }
-        }
+        CardCarousel(
+            cards = cards,
+            onSwipeDown = {
+                if (panel == PanelState.None) panel = PanelState.Top
+                else if (panel == PanelState.Bottom) panel = PanelState.None
+            },
+            onSwipeUp = {
+                if (panel == PanelState.None) panel = PanelState.Bottom
+                else if (panel == PanelState.Top) panel = PanelState.None
+            },
+            locationName = "Amaravati"
+        )
 
         if (panel != PanelState.None) {
             Box(
@@ -113,50 +71,6 @@ fun HomeScreen() {
             exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(150))
         ) {
             BottomPanel(onDismiss = { panel = PanelState.None })
-        }
-    }
-}
-
-
-@Composable
-private fun SummaryCard() {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(32.dp)
-            .height(180.dp),
-        colors = CardDefaults.cardColors(containerColor = Color(0xFFE8F4FF)),
-        elevation = CardDefaults.cardElevation(4.dp)
-    ) {
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text(
-                "Overview",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold
-            )
-        }
-    }
-}
-
-@Composable
-private fun NumberRow(count: Int, activeIndex: Int, onTap: (Int) -> Unit) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 8.dp),
-        horizontalArrangement = Arrangement.Center
-    ) {
-        repeat(count) { idx ->
-            val selected = idx == activeIndex
-            Text(
-                text = "${idx + 1}",
-                modifier = Modifier
-                    .padding(horizontal = 8.dp)
-                    .clickable { onTap(idx) },
-                color = if (selected) MaterialTheme.colorScheme.primary else Color.Gray,
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal
-            )
         }
     }
 }

--- a/app/src/main/java/com/example/basic/SummaryCard.kt
+++ b/app/src/main/java/com/example/basic/SummaryCard.kt
@@ -1,0 +1,37 @@
+package com.example.basic
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SummaryCard() {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(32.dp)
+            .height(180.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFE8F4FF)),
+        elevation = CardDefaults.cardElevation(4.dp)
+    ) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text(
+                "Overview",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `CardCarousel` composable replicating the React Native carousel
- extract `SummaryCard` into its own file
- use `CardCarousel` inside `HomeScreen`

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5a3369ec832f9e2ed4b7f91f44aa