### PR TITLE
Adjust card height and clean up border

### DIFF
--- a/app/src/main/java/com/example/basic/ClassCard.kt
+++ b/app/src/main/java/com/example/basic/ClassCard.kt
@@ -53,7 +53,7 @@ fun ClassCard(
     val wPx = with(density) { config.screenWidthDp.dp.toPx() }
     val hPx = with(density) { config.screenHeightDp.dp.toPx() }
     val cardW = wPx * 0.85f
-    val cardH = hPx * 0.75f
+    val cardH = hPx * 0.7f
     val cardWidth = with(density) { cardW.toDp() }
     val cardHeight = with(density) { cardH.toDp() }
 

--- a/vit-student-app/src/components/Card.tsx
+++ b/vit-student-app/src/components/Card.tsx
@@ -23,7 +23,7 @@ import useWeather from '../hooks/useWeather';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 export const CARD_WIDTH = SCREEN_WIDTH * 0.85;
-export const CARD_HEIGHT = SCREEN_HEIGHT * 0.75;
+export const CARD_HEIGHT = SCREEN_HEIGHT * 0.7;
 
 /** Number of raindrops */
 const RAINDROP_COUNT = 12;
@@ -528,9 +528,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
     paddingVertical: 16,
     borderRadius: 16,
-    borderWidth: 1,
-    borderColor: 'rgba(255,255,255,0.3)',
-
     backgroundColor: 'rgba(0,0,0,0.25)',
 
     zIndex: 3,


### PR DESCRIPTION
## Summary
- shrink card height on web/native sides
- drop white border from back of the card

## Testing
- `npm test --prefix vit-student-app` *(fails: Missing script "test")*
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685d5c378250832fa1ee3c115040ee46