### PR TITLE
Implement sticky week headers

### DIFF
--- a/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.animateItemPlacement
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
@@ -11,6 +12,7 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material3.*
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.draw.alpha
 import androidx.compose.runtime.*
@@ -82,7 +84,7 @@ private fun toWeeks(menu: MonthlyMenu): List<WeekSection> {
     return weeks
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun MonthlyMenuScreen(onBack: () -> Unit) {
     val context = LocalContext.current
@@ -118,8 +120,12 @@ fun MonthlyMenuScreen(onBack: () -> Unit) {
     ) { padding ->
         LazyColumn(modifier = Modifier.padding(padding)) {
             weeks.forEach { week ->
-                item {
-                    WeekHeader(title = week.title, color = week.color, dayColor = week.dayColor)
+                stickyHeader {
+                    WeekHeader(
+                        title = week.title,
+                        color = week.color,
+                        modifier = Modifier.animateItemPlacement()
+                    )
                 }
                 items(week.days) { day ->
                     DayBlock(
@@ -138,9 +144,9 @@ fun MonthlyMenuScreen(onBack: () -> Unit) {
 }
 
 @Composable
-private fun WeekHeader(title: String, color: Color, dayColor: Color) {
+private fun WeekHeader(title: String, color: Color, modifier: Modifier = Modifier) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .background(color)
             .padding(8.dp)

--- a/vit-student-app/src/screens/MonthlyMenuScreen.tsx
+++ b/vit-student-app/src/screens/MonthlyMenuScreen.tsx
@@ -202,7 +202,7 @@ export default function MonthlyMenuScreen() {
         )}
         onScrollToIndexFailed={handleScrollToIndexFailed}
         SectionSeparatorComponent={() => <View style={{ height: 12 }} />}
-        stickySectionHeadersEnabled={false}
+        stickySectionHeadersEnabled
         contentContainerStyle={styles.listContent}
       />
     </SafeAreaView>


### PR DESCRIPTION
## Summary
- float week headers for Compose `MonthlyMenuScreen` using `stickyHeader`
- add `animateItemPlacement` to animate header transitions
- enable sticky headers in React Native `MonthlyMenuScreen`
- fix imports and add `ExperimentalFoundationApi` opt-in

## Testing
- `./gradlew test` *(fails: Unable to access jarfile gradle-wrapper.jar)*
- `npm test` in `vit-student-app` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685d5b8da9fc832f8c404d737e2735db