### PR TITLE
Fix card flip outline

### DIFF
--- a/app/src/main/java/com/example/basic/ClassCard.kt
+++ b/app/src/main/java/com/example/basic/ClassCard.kt
@@ -81,7 +81,7 @@ fun ClassCard(
             .width(cardWidth)
             .height(cardHeight)
             .padding(vertical = 16.dp)
-            .shadow(8.dp, RoundedCornerShape(20.dp), clip = false)
+            .shadow(8.dp, RoundedCornerShape(20.dp), clip = true)
             .pointerInput(Unit) { detectTapGestures(onDoubleTap = { flipped = !flipped }) }
     ) {
         // FRONT


### PR DESCRIPTION
## Summary
- clip ClassCard's shadow to rounded corners to remove white outline during flips

## Testing
- `gradle wrapper`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5d8bc73c832fbe743a4b77805b81