### PR TITLE
Remove default action bar

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
         android:icon="@android:drawable/ic_menu_gallery"
         android:roundIcon="@android:drawable/ic_menu_gallery"
         android:supportsRtl="true"
-        android:theme="@android:style/Theme.Material.Light">
+        android:theme="@android:style/Theme.Material.Light.NoActionBar">
         <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
## Summary
- hide the automatic ActionBar so the app no longer shows the "Basic App" bar

## Testing
- `./gradlew test` *(fails: unable to access gradle wrapper jar)*
- `npm test` in `vit-student-app` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d68193378832f8db1df442d603ab7