### PR TITLE
Fix carousel layout and clipping

### DIFF
--- a/app/src/main/java/com/example/basic/CardCarousel.kt
+++ b/app/src/main/java/com/example/basic/CardCarousel.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.shape.CircleShape
 import kotlinx.coroutines.launch
@@ -36,6 +37,12 @@ fun CardCarousel(
     val scope = rememberCoroutineScope()
     var dragAmount by remember { mutableStateOf(0f) }
 
+    // Calculate vertical offset for the number row so it sits just under the cards
+    val config = LocalConfiguration.current
+    val screenHeight = config.screenHeightDp.dp
+    val cardHeight = screenHeight * 0.7f
+    val numberTop = (screenHeight - cardHeight) / 3f + cardHeight + 20.dp
+
     LaunchedEffect(pagerState.currentPage) {
         onIndexChange?.invoke(pagerState.currentPage)
     }
@@ -43,6 +50,7 @@ fun CardCarousel(
     Box(
         modifier = modifier
             .fillMaxSize()
+            .graphicsLayer { clip = false }
             .pointerInput(Unit) {
                 detectDragGestures(
                     onDrag = { _, drag ->
@@ -57,7 +65,9 @@ fun CardCarousel(
     ) {
         HorizontalPager(
             state = pagerState,
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer { clip = false }
         ) { page ->
             if (page == 0) {
                 SummaryCard()
@@ -79,7 +89,7 @@ fun CardCarousel(
                 onTap = { idx -> scope.launch { pagerState.animateScrollToPage(idx + 1) } },
                 modifier = Modifier
                     .align(Alignment.TopCenter)
-                    .padding(top = 16.dp)
+                    .padding(top = numberTop)
             )
 
             Text(

--- a/app/src/main/java/com/example/basic/ClassCard.kt
+++ b/app/src/main/java/com/example/basic/ClassCard.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -81,7 +80,6 @@ fun ClassCard(
             .width(cardWidth)
             .height(cardHeight)
             .padding(vertical = 16.dp)
-            .shadow(8.dp, RoundedCornerShape(20.dp), clip = false)
             .pointerInput(Unit) { detectTapGestures(onDoubleTap = { flipped = !flipped }) }
     ) {
         // FRONT
@@ -93,13 +91,13 @@ fun ClassCard(
                     cameraDistance = 8 * density.density
                     alpha = if (rotation <= 90f) 1f else 0f
                 }
-                .clip(RoundedCornerShape(20.dp))
                 .background(
                     Brush.linearGradient(
                         colors = gradientColors,
                         start = Offset.Zero,
                         end = Offset(cardW, cardH)
-                    )
+                    ),
+                    shape = RoundedCornerShape(20.dp)
                 )
         ) {
             BlobPattern(cardWidth, cardHeight)
@@ -198,13 +196,13 @@ fun ClassCard(
                     cameraDistance = 8 * density.density
                     alpha = if (rotation > 90f) 1f else 0f
                 }
-                .clip(RoundedCornerShape(20.dp))
                 .background(
                     Brush.linearGradient(
                         colors = gradientColors,
                         start = Offset.Zero,
                         end = Offset(cardW, cardH)
-                    )
+                    ),
+                    shape = RoundedCornerShape(20.dp)
                 )
         ) {
             BlobPattern(cardWidth, cardHeight)


### PR DESCRIPTION
## Summary
- keep HorizontalPager and carousel container unclipped
- position page number row using top padding
- draw card faces with rounded background but no clipping

## Testing
- `./gradlew test` *(fails: Unable to access gradle wrapper jar)*

------
https://chatgpt.com/codex/tasks/task_e_685d5dee35f4832f933312f5614882b5