### PR TITLE
Fix card alignment and clipping

### DIFF
--- a/app/src/main/java/com/example/basic/CardCarousel.kt
+++ b/app/src/main/java/com/example/basic/CardCarousel.kt
@@ -69,15 +69,20 @@ fun CardCarousel(
                 .fillMaxSize()
                 .graphicsLayer { clip = false }
         ) { page ->
-            if (page == 0) {
-                SummaryCard()
-            } else {
-                ClassCard(
-                    info = cards[page],
-                    index = page - 1,
-                    daySchedule = cards.drop(1),
-                    locationName = locationName
-                )
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                if (page == 0) {
+                    SummaryCard()
+                } else {
+                    ClassCard(
+                        info = cards[page],
+                        index = page - 1,
+                        daySchedule = cards.drop(1),
+                        locationName = locationName
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/com/example/basic/ClassCard.kt
+++ b/app/src/main/java/com/example/basic/ClassCard.kt
@@ -92,13 +92,13 @@ fun ClassCard(
                     cameraDistance = 8 * density.density
                     alpha = if (rotation <= 90f) 1f else 0f
                 }
+                .clip(RoundedCornerShape(20.dp))
                 .background(
                     Brush.linearGradient(
                         colors = gradientColors,
                         start = Offset.Zero,
                         end = Offset(cardW, cardH)
-                    ),
-                    shape = RoundedCornerShape(20.dp)
+                    )
                 )
         ) {
             BlobPattern(cardWidth, cardHeight)
@@ -197,13 +197,13 @@ fun ClassCard(
                     cameraDistance = 8 * density.density
                     alpha = if (rotation > 90f) 1f else 0f
                 }
+                .clip(RoundedCornerShape(20.dp))
                 .background(
                     Brush.linearGradient(
                         colors = gradientColors,
                         start = Offset.Zero,
                         end = Offset(cardW, cardH)
-                    ),
-                    shape = RoundedCornerShape(20.dp)
+                    )
                 )
         ) {
             BlobPattern(cardWidth, cardHeight)


### PR DESCRIPTION
## Summary
- center home page cards in `HorizontalPager`
- clip card overlays so the background doesn't peek through

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685d69b26be0832faee62ba628ed0038