### PR TITLE
Fix weekly header rounding and add day separators

### DIFF
--- a/vit-student-app/src/screens/MonthlyMenuScreen.tsx
+++ b/vit-student-app/src/screens/MonthlyMenuScreen.tsx
@@ -219,6 +219,8 @@ const styles = StyleSheet.create({
     padding: 8,
     borderTopLeftRadius: 12,
     borderTopRightRadius: 12,
+    borderBottomLeftRadius: 12,
+    borderBottomRightRadius: 12,
     alignItems: 'center',
   },
   weekLabel: {
@@ -235,8 +237,9 @@ const styles = StyleSheet.create({
   dayBlock: {
     padding: 12,
     marginHorizontal: 4,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#bbb',
+    borderBottomWidth: 1,
+    borderBottomColor: '#555',
+    borderStyle: 'dotted',
   },
   firstDay: { borderTopLeftRadius: 12, borderTopRightRadius: 12, marginTop: 4 },
   lastDay: {


### PR DESCRIPTION
## Summary
- keep rounded corners on sticky week headers
- add dotted separators below each day's menu

## Testing
- `npm test` *(fails: Missing script)*
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685d72abd7ec832f9f9d45308a25af85