### PR TITLE
Adjust card UI

### DIFF
--- a/app/src/main/java/com/example/basic/ClassCard.kt
+++ b/app/src/main/java/com/example/basic/ClassCard.kt
@@ -115,8 +115,18 @@ fun ClassCard(
                     .align(Alignment.TopStart)
                     .padding(start = 24.dp, top = 20.dp)
             ) {
-                Text(weekday, color = Color.White, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
-                Text(dateNum, color = Color.White, fontSize = 12.sp)
+                Text(
+                    weekday,
+                    color = Color.White,
+                    fontSize = 36.sp,
+                    fontWeight = FontWeight.Black
+                )
+                Text(
+                    dateNum,
+                    color = Color.White,
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Bold
+                )
             }
 
             // Weather badge
@@ -136,7 +146,7 @@ fun ClassCard(
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .padding(top = 88.dp, end = 24.dp)
+                    .padding(top = 80.dp, end = 24.dp)
             )
 
             val parts = remember(info.title) {


### PR DESCRIPTION
## Summary
- enlarge weekday/date text on class cards
- nudge city label closer to the weather badge

## Testing
- `./gradlew test` *(fails: unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685d7434091c832fab976e61774bdf43