### PR TITLE
Fix Amaravati label spacing

### DIFF
--- a/app/src/main/java/com/example/basic/ClassCard.kt
+++ b/app/src/main/java/com/example/basic/ClassCard.kt
@@ -146,7 +146,7 @@ fun ClassCard(
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .padding(top = 80.dp, end = 24.dp)
+                    .padding(top = 68.dp, end = 24.dp)
             )
 
             val parts = remember(info.title) {


### PR DESCRIPTION
## Summary
- adjust the `locationName` label position so it sits right below the weather badge

## Testing
- `npm test` *(fails: Missing script)*
- `./gradlew test` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_685d7779ea4c832f8acac5ba28401a7e