### PR TITLE
Make planner class boxes touch-reactive

### DIFF
--- a/app/src/main/java/com/example/basic/PlannerScreen.kt
+++ b/app/src/main/java/com/example/basic/PlannerScreen.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import android.widget.Toast
 
 @Composable
 fun PlannerScreen() {
@@ -30,6 +32,7 @@ fun PlannerScreen() {
     val day = days[dayIndex]
     val classes = WEEKLY_SCHEDULE[day].orEmpty()
     var dragAmount by remember { mutableStateOf(0f) }
+    val context = LocalContext.current
 
     Column(
         modifier = Modifier
@@ -89,7 +92,14 @@ fun PlannerScreen() {
                 Card(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(vertical = 6.dp),
+                        .padding(vertical = 6.dp)
+                        .clickable {
+                            Toast.makeText(
+                                context,
+                                "${cls.course} ${cls.start} – ${cls.end} @ ${cls.room}",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        },
                     colors = CardDefaults.cardColors(containerColor = Color.White),
                     elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
                     shape = RoundedCornerShape(12.dp)

--- a/vit-student-app/src/screens/Planner.tsx
+++ b/vit-student-app/src/screens/Planner.tsx
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
+  Alert,
   Platform,
   StatusBar,
   PanResponder,
@@ -79,7 +80,17 @@ export default function Planner() {
         {...pan.panHandlers}
       >
         {classes.map((cls, idx) => (
-          <View key={idx} style={styles.classBox}>
+          <TouchableOpacity
+            key={idx}
+            style={styles.classBox}
+            activeOpacity={0.7}
+            onPress={() =>
+              Alert.alert(
+                cls.course,
+                `${cls.start} – ${cls.end} @ ${cls.room}`
+              )
+            }
+          >
             <View style={styles.classLeft}>
               <Text style={styles.courseText}>{cls.course}</Text>
               <Text style={styles.facultyText}>{cls.faculty}</Text>
@@ -90,7 +101,7 @@ export default function Planner() {
               </Text>
               <Text style={styles.roomText}>{cls.room}</Text>
             </View>
-          </View>
+          </TouchableOpacity>
         ))}
       </ScrollView>
     </SafeAreaView>


### PR DESCRIPTION
## Summary
- alert class details when tapping class boxes in React Native Planner
- show a toast with class details when tapping class cards in Jetpack Compose Planner

## Testing
- `npm test` *(fails: Missing script)*
- `./gradlew test` *(fails: Unable to access jarfile gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685d78d24320832f9a5e709ff7284762