### PR TITLE
Refine class box touch effects

### DIFF
--- a/app/src/main/java/com/example/basic/PlannerScreen.kt
+++ b/app/src/main/java/com/example/basic/PlannerScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.pointer.pointerInput
-
 @Composable
 fun PlannerScreen() {
     val days = WEEKLY_SCHEDULE.keys.toList()
@@ -87,6 +86,7 @@ fun PlannerScreen() {
         ) {
             items(classes) { cls ->
                 Card(
+                    onClick = {},
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(vertical = 6.dp),

--- a/vit-student-app/src/screens/Planner.tsx
+++ b/vit-student-app/src/screens/Planner.tsx
@@ -79,7 +79,11 @@ export default function Planner() {
         {...pan.panHandlers}
       >
         {classes.map((cls, idx) => (
-          <View key={idx} style={styles.classBox}>
+          <TouchableOpacity
+            key={idx}
+            style={styles.classBox}
+            activeOpacity={0.7}
+          >
             <View style={styles.classLeft}>
               <Text style={styles.courseText}>{cls.course}</Text>
               <Text style={styles.facultyText}>{cls.faculty}</Text>
@@ -90,7 +94,7 @@ export default function Planner() {
               </Text>
               <Text style={styles.roomText}>{cls.room}</Text>
             </View>
-          </View>
+          </TouchableOpacity>
         ))}
       </ScrollView>
     </SafeAreaView>
@@ -126,6 +130,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     backgroundColor: '#fff',
     borderRadius: 12,
+    overflow: 'hidden',
     paddingVertical: 10,
     paddingHorizontal: 12,
     marginVertical: 6,


### PR DESCRIPTION
## Summary
- use `onClick` within Compose `Card` so ripple respects rounded corners
- hide Android ripple outside React Native class boxes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `./gradlew test` *(fails: Unable to access jarfile gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685d78d24320832f9a5e709ff7284762