### PR TITLE
Fix monthly menu header clipping

### DIFF
--- a/vit-student-app/src/screens/MonthlyMenuScreen.tsx
+++ b/vit-student-app/src/screens/MonthlyMenuScreen.tsx
@@ -192,11 +192,16 @@ export default function MonthlyMenuScreen() {
           renderDay(item, index, section as WeekSection)
         }
         renderSectionHeader={({ section }) => (
-          <View
-            style={[styles.weekHeaderContainer, { backgroundColor: section.dayColor }]}
-          >
-            <View style={styles.weekLabel}>
-              <Text style={styles.sectionHeader}>{section.title}</Text>
+          <View style={styles.weekHeaderWrapper}>
+            <View
+              style={[
+                styles.weekHeaderContainer,
+                { backgroundColor: section.dayColor },
+              ]}
+            >
+              <View style={styles.weekLabel}>
+                <Text style={styles.sectionHeader}>{section.title}</Text>
+              </View>
             </View>
           </View>
         )}
@@ -213,6 +218,9 @@ const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: '#f2f2f2' },
   centered: { flex: 1, justifyContent: 'center', alignItems: 'center' },
   listContent: { padding: 12 },
+  weekHeaderWrapper: {
+    backgroundColor: '#f2f2f2',
+  },
   weekHeaderContainer: {
     marginHorizontal: 4,
     marginBottom: 4,


### PR DESCRIPTION
## Summary
- wrap week headers in a background container
- add style for wrapper to match screen background

This keeps scrolling menu items from appearing in the rounded corners of the sticky week header.

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d7d89507c832fbe92200bbabc301f