### PR TITLE
Add slide animation to planner screen

### DIFF
--- a/app/src/main/java/com/example/basic/PlannerScreen.kt
+++ b/app/src/main/java/com/example/basic/PlannerScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.items
+import androidx.compose.animation.*
+import androidx.compose.animation.core.tween
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -29,8 +31,6 @@ import androidx.compose.ui.input.pointer.pointerInput
 fun PlannerScreen() {
     val days = WEEKLY_SCHEDULE.keys.toList()
     var dayIndex by remember { mutableStateOf(0) }
-    val day = days[dayIndex]
-    val classes = WEEKLY_SCHEDULE[day].orEmpty()
     var dragAmount by remember { mutableStateOf(0f) }
 
     Column(
@@ -63,31 +63,57 @@ fun PlannerScreen() {
                 .padding(vertical = 16.dp, horizontal = 16.dp)
         )
 
-        LazyRow(
-            modifier = Modifier.padding(bottom = 8.dp),
-            contentPadding = PaddingValues(horizontal = 16.dp)
-        ) {
-            itemsIndexed(days) { i, d ->
-                val selected = i == dayIndex
-                Text(
-                    text = d.take(3),
-                    fontSize = 14.sp,
-                    fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
-                    color = if (selected) Color.White else Color(0xFF333333),
-                    modifier = Modifier
-                        .padding(end = 8.dp)
-                        .clip(RoundedCornerShape(20.dp))
-                        .background(if (selected) Color(0xFF6C5CE7) else Color(0xFFE0E0E0))
-                        .clickable { dayIndex = i }
-                        .padding(horizontal = 12.dp, vertical = 8.dp)
-                )
+        AnimatedContent(
+            targetState = dayIndex,
+            transitionSpec = {
+                if (targetState > initialState) {
+                    slideInHorizontally({ it }) + fadeIn() with
+                            slideOutHorizontally({ -it }) + fadeOut()
+                } else {
+                    slideInHorizontally({ -it }) + fadeIn() with
+                            slideOutHorizontally({ it }) + fadeOut()
+                }
+            }
+        ) { index ->
+            LazyRow(
+                modifier = Modifier.padding(bottom = 8.dp),
+                contentPadding = PaddingValues(horizontal = 16.dp)
+            ) {
+                itemsIndexed(days) { i, d ->
+                    val selected = i == index
+                    Text(
+                        text = d.take(3),
+                        fontSize = 14.sp,
+                        fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
+                        color = if (selected) Color.White else Color(0xFF333333),
+                        modifier = Modifier
+                            .padding(end = 8.dp)
+                            .clip(RoundedCornerShape(20.dp))
+                            .background(if (selected) Color(0xFF6C5CE7) else Color(0xFFE0E0E0))
+                            .clickable { dayIndex = i }
+                            .padding(horizontal = 12.dp, vertical = 8.dp)
+                    )
+                }
             }
         }
 
-        LazyColumn(
-            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 4.dp)
-        ) {
-            items(classes) { cls ->
+        AnimatedContent(
+            targetState = dayIndex,
+            transitionSpec = {
+                if (targetState > initialState) {
+                    slideInHorizontally({ it }) + fadeIn() with
+                            slideOutHorizontally({ -it }) + fadeOut()
+                } else {
+                    slideInHorizontally({ -it }) + fadeIn() with
+                            slideOutHorizontally({ it }) + fadeOut()
+                }
+            }
+        ) { index ->
+            val classes = WEEKLY_SCHEDULE[days[index]].orEmpty()
+            LazyColumn(
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 4.dp)
+            ) {
+                items(classes) { cls ->
                 Card(
                     onClick = {},
                     modifier = Modifier
@@ -131,6 +157,7 @@ fun PlannerScreen() {
                             )
                         }
                     }
+                }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- animate timetable day changes
- slide day row and schedule when swiping

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7df7484c832fa6f46872a0f7a032