### PR TITLE
Fix monthly menu header border while sticky

### DIFF
--- a/vit-student-app/src/screens/MonthlyMenuScreen.tsx
+++ b/vit-student-app/src/screens/MonthlyMenuScreen.tsx
@@ -6,6 +6,9 @@ import {
   SectionList,
   ActivityIndicator,
   Pressable,
+  NativeSyntheticEvent,
+  NativeScrollEvent,
+  LayoutChangeEvent,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Ionicons from '@expo/vector-icons/Ionicons';
@@ -33,6 +36,7 @@ type WeekSection = {
   color: string;
   dayColor: string;
   data: { date: string; meals: Meal[] }[];
+  index: number;
 };
 
 export default function MonthlyMenuScreen() {
@@ -45,6 +49,8 @@ export default function MonthlyMenuScreen() {
   const [likes, setLikes] = useState<Record<string, boolean>>({});
   const listRef = useRef<SectionList<any>>(null);
   const scrollTarget = useRef<{ sectionIndex: number; itemIndex: number }>();
+  const headerPositions = useRef<number[]>([]);
+  const [stickyIndex, setStickyIndex] = useState(0);
 
   useEffect(() => {
     const loadMenu = async () => {
@@ -102,6 +108,26 @@ export default function MonthlyMenuScreen() {
     }, 50);
   };
 
+  const handleHeaderLayout = (index: number) =>
+    (e: LayoutChangeEvent) => {
+      headerPositions.current[index] = e.nativeEvent.layout.y;
+    };
+
+  const handleScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const offset = e.nativeEvent.contentOffset.y;
+    let active = 0;
+    for (let i = 0; i < headerPositions.current.length; i++) {
+      if (headerPositions.current[i] <= offset) {
+        active = i;
+      } else {
+        break;
+      }
+    }
+    if (active !== stickyIndex) {
+      setStickyIndex(active);
+    }
+  };
+
   const toWeeks = (): WeekSection[] => {
     if (!menu) return [];
 
@@ -115,6 +141,7 @@ export default function MonthlyMenuScreen() {
         color: WEEK_COLORS[index % WEEK_COLORS.length],
         dayColor: DAY_COLORS[index % DAY_COLORS.length],
         data: slice.map((d) => ({ date: d, meals: menu[d] })),
+        index,
       });
     }
     return weeks;
@@ -186,6 +213,8 @@ export default function MonthlyMenuScreen() {
     <SafeAreaView style={styles.safe}>
       <SectionList
         ref={listRef}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
         sections={toWeeks()}
         keyExtractor={(item) => item.date}
         renderItem={({ item, index, section }) =>
@@ -193,7 +222,12 @@ export default function MonthlyMenuScreen() {
         }
         renderSectionHeader={({ section }) => (
           <View
-            style={[styles.weekHeaderContainer, { backgroundColor: section.dayColor }]}
+            onLayout={handleHeaderLayout(section.index)}
+            style={[
+              styles.weekHeaderContainer,
+              { backgroundColor: section.dayColor },
+              stickyIndex === section.index && styles.weekHeaderSticky,
+            ]}
           >
             <View style={styles.weekLabel}>
               <Text style={styles.sectionHeader}>{section.title}</Text>
@@ -223,6 +257,9 @@ const styles = StyleSheet.create({
     borderBottomRightRadius: 12,
     overflow: 'hidden',
     alignItems: 'center',
+  },
+  weekHeaderSticky: {
+    borderRadius: 0,
   },
   weekLabel: {
     backgroundColor: '#000',


### PR DESCRIPTION
## Summary
- track week header positions to detect active sticky header
- square header corners when sticky instead of using a wrapper

## Testing
- `npm test` *(fails: Missing script)*
- `npx --yes tsc -p vit-student-app/tsconfig.json --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_685d7d89507c832fbe92200bbabc301f