### PR TITLE
Remove rain animation from cards

### DIFF
--- a/app/src/main/java/com/example/basic/ClassCard.kt
+++ b/app/src/main/java/com/example/basic/ClassCard.kt
@@ -35,7 +35,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle
 import java.util.Locale
-import kotlin.random.Random
 
 // Shared data model
 data class ClassInfo(val id: String, val title: String, val time: String)
@@ -107,7 +106,6 @@ fun ClassCard(
                     .matchParentSize()
                     .background(Color.Black.copy(alpha = 0.2f))
             )
-            Raindrops(cardWidth, cardHeight)
 
             // Weekday and date
             Column(
@@ -290,53 +288,6 @@ private fun BlobPattern(cardWidth: Dp, cardHeight: Dp) {
     }
 }
 
-@Composable
-private fun Raindrops(cardWidth: Dp, cardHeight: Dp) {
-    val density = LocalDensity.current
-    val widthPx = with(density) { cardWidth.toPx() }
-    val heightPx = with(density) { cardHeight.toPx() }
-    val drops = remember {
-        List(12) {
-            mutableStateOf(RandomDropState(
-                anim = Animatable(-Random.nextFloat() * heightPx)
-            ))
-        }
-    }
-
-    drops.forEach { state ->
-        LaunchedEffect(state) {
-            while (true) {
-                state.value.anim.snapTo(-20f)
-                state.value.anim.animateTo(
-                    targetValue = heightPx + 20f,
-                    animationSpec = tween(
-                        durationMillis = (6000 + Random.nextInt(4000)),
-                        easing = LinearEasing,
-                        delayMillis = Random.nextInt(0, 1200)
-                    )
-                )
-            }
-        }
-    }
-
-    Canvas(modifier = Modifier.fillMaxSize()) {
-        drops.forEach { state ->
-            val x = state.value.xPos(widthPx)
-            drawRoundRect(
-                color = Color.White.copy(alpha = 0.6f),
-                topLeft = Offset(x, state.value.anim.value),
-                size = androidx.compose.ui.geometry.Size(1f, 12f),
-                cornerRadius = androidx.compose.ui.geometry.CornerRadius(0.5f, 0.5f)
-            )
-        }
-    }
-}
-
-private class RandomDropState(
-    val anim: Animatable<Float, AnimationVector1D>
-) {
-    fun xPos(width: Float) = Random.nextFloat() * (width - 2f) + 1f
-}
 
 @Composable
 private fun TemperatureBadge(

--- a/vit-student-app/src/components/Card.tsx
+++ b/vit-student-app/src/components/Card.tsx
@@ -25,12 +25,6 @@ const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 export const CARD_WIDTH = SCREEN_WIDTH * 0.85;
 export const CARD_HEIGHT = SCREEN_HEIGHT * 0.7;
 
-/** Number of raindrops */
-const RAINDROP_COUNT = 12;
-/** Base duration for extremely slow raindrops */
-const RAINDROP_BASE_DURATION = 30000; // 30 seconds
-/** Additional random duration variance */
-const RAINDROP_DURATION_VARIANCE = 20000; // up to 20s slower
 
 function isClassOver(timeRange: string) {
   const parts = timeRange.split('–').map((s) => s.trim());
@@ -196,7 +190,6 @@ export default function Card({
             style={styles.gradient}
           >
             <BlobPattern />
-            <Raindrops />
             <View style={styles.darkenOverlay} />
 
             {/* WEEKDAY & DATE */}
@@ -303,74 +296,6 @@ export default function Card({
         onSubmit={submitRating}
         initialRating={currentRating}
       />
-    </View>
-  );
-}
-
-/** Raindrops animation **/
-function Raindrops() {
-  const drops = useRef<{
-    anim: Animated.Value;
-    xPos: number;
-    delay: number;
-    speed: number;
-  }[]>(
-    Array.from({ length: RAINDROP_COUNT }).map(() => ({
-      anim: new Animated.Value(-Math.random() * CARD_HEIGHT),
-      xPos: Math.random() * (CARD_WIDTH - 2) + 1,
-      delay: Math.random() * 2000,
-      speed:
-        RAINDROP_BASE_DURATION + Math.random() * RAINDROP_DURATION_VARIANCE,
-    }))
-  ).current;
-
-  useEffect(() => {
-    drops.forEach(({ anim, delay, speed }) => {
-      const loop = () => {
-        anim.setValue(-20);
-        Animated.timing(anim, {
-          toValue: CARD_HEIGHT + 20,
-          duration: speed,
-          delay,
-          easing: Easing.linear,
-          useNativeDriver: true,
-        }).start(({ finished }) => {
-          if (finished) {
-            const newSpeed =
-              RAINDROP_BASE_DURATION +
-              Math.random() * RAINDROP_DURATION_VARIANCE;
-            const newDelay = Math.random() * 1200;
-            anim.setValue(-20);
-            Animated.timing(anim, {
-              toValue: CARD_HEIGHT + 20,
-              duration: newSpeed,
-              delay: newDelay,
-              easing: Easing.linear,
-              useNativeDriver: true,
-            }).start(({ finished: f2 }) => {
-              if (f2) loop();
-            });
-          }
-        });
-      };
-      loop();
-    });
-  }, [drops]);
-
-  return (
-    <View style={StyleSheet.absoluteFill}>
-      {drops.map(({ anim, xPos }, idx) => (
-        <Animated.View
-          key={idx}
-          style={[
-            styles.raindrop,
-            {
-              left: xPos,
-              transform: [{ translateY: anim }],
-            },
-          ]}
-        />
-      ))}
     </View>
   );
 }
@@ -521,13 +446,6 @@ const styles = StyleSheet.create({
     color: '#f0f0f0',
     alignSelf: 'flex-start',
     marginLeft: 20,
-  },
-  raindrop: {
-    position: 'absolute',
-    width: 1,
-    height: 12,
-    borderRadius: 0.5,
-    backgroundColor: 'rgba(255, 255, 255, 0.6)',
   },
   backContent: {
     flex: 1,


### PR DESCRIPTION
## Summary
- delete raindrop animation code from React Native `Card` component
- remove the matching raindrop animation from Compose `ClassCard`

## Testing
- `npm test` *(fails: missing script)*
- `./gradlew :app:assembleDebug` *(fails: unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685d7f8d26b0832f82f248f99bc29d6e