### PR TITLE
Enlarge home tab icon

### DIFF
--- a/vit-student-app/App.tsx
+++ b/vit-student-app/App.tsx
@@ -91,7 +91,9 @@ function MainTabs() {
               : 'ellipsis-horizontal-outline';
           }
 
-          return <Ionicons name={iconName} size={size} color={color} />;
+          // Slightly enlarge the Home icon so it stands out on the main tab
+          const iconSize = route.name === 'Home' ? size + 4 : size;
+          return <Ionicons name={iconName} size={iconSize} color={color} />;
         },
         tabBarActiveTintColor: '#000000',
         tabBarInactiveTintColor: '#555555',


### PR DESCRIPTION
## Summary
- tweak tab bar icon logic to enlarge the Home icon

## Testing
- `./gradlew test` *(fails: unable to access jarfile)*
- `npm test` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_685d81afdfc4832fa56e09b53ce6bf95