### PR TITLE
Add wishlist to monthly menu

### DIFF
--- a/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
@@ -117,6 +117,8 @@ fun MonthlyMenuScreen(onBack: () -> Unit) {
 
     val weeks = remember(menu) { toWeeks(menu!!) }
     val today = remember { java.text.SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date()) }
+    var showWishlist by remember { mutableStateOf(false) }
+    val wishlistItems = likes.filter { it.value }.keys.toList()
 
     val listState = rememberLazyListState()
 
@@ -153,6 +155,15 @@ fun MonthlyMenuScreen(onBack: () -> Unit) {
                 },
                 navigationIcon = {
                     IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, contentDescription = "Back") }
+                },
+                actions = {
+                    IconButton(onClick = { showWishlist = true }) {
+                        Icon(
+                            imageVector = Icons.Default.Favorite,
+                            contentDescription = "Wishlist",
+                            tint = if (wishlistItems.isNotEmpty()) Color.Red else LocalContentColor.current
+                        )
+                    }
                 }
             )
         }
@@ -188,6 +199,27 @@ fun MonthlyMenuScreen(onBack: () -> Unit) {
                 }
             }
         }
+    }
+
+    if (showWishlist) {
+        AlertDialog(
+            onDismissRequest = { showWishlist = false },
+            confirmButton = {
+                TextButton(onClick = { showWishlist = false }) { Text("Close") }
+            },
+            title = { Text("Wishlist") },
+            text = {
+                if (wishlistItems.isEmpty()) {
+                    Text("No favourites yet.")
+                } else {
+                    LazyColumn {
+                        items(wishlistItems) { item ->
+                            Text(item)
+                        }
+                    }
+                }
+            }
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- display wishlist items on monthly menu screen
- show a red heart icon in the app bar that opens the wishlist list

## Testing
- `./gradlew assembleDebug` *(fails: Invalid or corrupt jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_685d8479cdb0832fb14f59a08a389950