### PR TITLE
Add swipe animations to Planner

### DIFF
--- a/app/src/main/java/com/example/basic/PlannerScreen.kt
+++ b/app/src/main/java/com/example/basic/PlannerScreen.kt
@@ -8,6 +8,15 @@ import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.items
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.with
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -24,13 +33,11 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.pointer.pointerInput
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalAnimationApi::class)
 @Composable
 fun PlannerScreen() {
     val days = WEEKLY_SCHEDULE.keys.toList()
     var dayIndex by remember { mutableStateOf(0) }
-    val day = days[dayIndex]
-    val classes = WEEKLY_SCHEDULE[day].orEmpty()
     var dragAmount by remember { mutableStateOf(0f) }
 
     Column(
@@ -69,40 +76,59 @@ fun PlannerScreen() {
         ) {
             itemsIndexed(days) { i, d ->
                 val selected = i == dayIndex
+                val bgColor by animateColorAsState(
+                    if (selected) Color(0xFF6C5CE7) else Color(0xFFE0E0E0),
+                    animationSpec = tween(300)
+                )
+                val textColor by animateColorAsState(
+                    if (selected) Color.White else Color(0xFF333333),
+                    animationSpec = tween(300)
+                )
                 Text(
                     text = d.take(3),
                     fontSize = 14.sp,
                     fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
-                    color = if (selected) Color.White else Color(0xFF333333),
+                    color = textColor,
                     modifier = Modifier
                         .padding(end = 8.dp)
                         .clip(RoundedCornerShape(20.dp))
-                        .background(if (selected) Color(0xFF6C5CE7) else Color(0xFFE0E0E0))
+                        .background(bgColor)
                         .clickable { dayIndex = i }
                         .padding(horizontal = 12.dp, vertical = 8.dp)
                 )
             }
         }
 
-        LazyColumn(
-            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 4.dp)
-        ) {
-            items(classes) { cls ->
-                Card(
-                    onClick = {},
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 6.dp),
-                    colors = CardDefaults.cardColors(containerColor = Color.White),
-                    elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
-                    shape = RoundedCornerShape(12.dp)
-                ) {
-                    Row(
+        AnimatedContent(
+            targetState = dayIndex,
+            transitionSpec = {
+                (slideInVertically(initialOffsetY = { it }, animationSpec = tween(300)) +
+                        fadeIn(animationSpec = tween(300))) with
+                        (slideOutVertically(targetOffsetY = { -it }, animationSpec = tween(300)) +
+                        fadeOut(animationSpec = tween(300)))
+            },
+            label = "classes"
+        ) { index ->
+            val classes = WEEKLY_SCHEDULE[days[index]].orEmpty()
+            LazyColumn(
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 4.dp)
+            ) {
+                items(classes) { cls ->
+                    Card(
+                        onClick = {},
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(vertical = 10.dp, horizontal = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                            .padding(vertical = 6.dp),
+                        colors = CardDefaults.cardColors(containerColor = Color.White),
+                        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
+                        shape = RoundedCornerShape(12.dp)
                     ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 10.dp, horizontal = 12.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
                                 text = cls.course,


### PR DESCRIPTION
## Summary
- animate day row colors on selection
- animate timetable changes with slide and fade
- fix compilation errors in PlannerScreen

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685d84ca1b4c832f8216438d2951eefb