### PR TITLE
Change button colors on Today's Menu

### DIFF
--- a/app/src/main/java/com/example/basic/FoodMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/FoodMenuScreen.kt
@@ -171,7 +171,7 @@ fun FoodMenuScreen(onShowSummary: () -> Unit, onViewMonth: () -> Unit = {}) {
             }
             Button(
                 onClick = onShowSummary,
-                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF007BFF)),
+                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF4CAF50)),
                 modifier = Modifier.align(Alignment.CenterHorizontally)
             ) {
                 Text("Food Summary", color = Color.White)
@@ -295,7 +295,7 @@ private fun MealCard(
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                 Button(
                     onClick = onRate,
-                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF007BFF))
+                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF9800))
                 ) {
                     Icon(Icons.Default.Star, contentDescription = null, tint = Color.White, modifier = Modifier.size(16.dp))
                     Spacer(Modifier.width(4.dp))


### PR DESCRIPTION
## Summary
- tweak `FoodMenuScreen.kt` button colors so Food Summary and Rate buttons aren't blue

## Testing
- `./gradlew assemble` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685d86ef9fac832f84155bbff076c12b