### PR TITLE
Sync Kotlin home design with TS

### DIFF
--- a/app/src/main/java/com/example/basic/ClassCard.kt
+++ b/app/src/main/java/com/example/basic/ClassCard.kt
@@ -134,7 +134,7 @@ fun ClassCard(
                 wind = "12 km/h",
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .padding(top = 12.dp, end = 24.dp)
+                    .padding(top = 20.dp, end = 20.dp)
             )
 
             Text(
@@ -297,7 +297,7 @@ private fun TemperatureBadge(
     modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = modifier,
+        modifier = modifier.padding(horizontal = 8.dp, vertical = 4.dp),
         horizontalAlignment = Alignment.End
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/java/com/example/basic/SummaryCard.kt
+++ b/app/src/main/java/com/example/basic/SummaryCard.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -81,20 +82,40 @@ private fun WeatherCard() {
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(Icons.Default.Cloud, contentDescription = null, tint = Color.White, modifier = Modifier.size(64.dp))
-                    Spacer(Modifier.width(8.dp))
-                    Text("Cloudy", color = Color.White, fontSize = 32.sp, fontWeight = FontWeight.Bold)
+                    Icon(
+                        Icons.Default.Cloud,
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(72.dp)
+                    )
+                    Spacer(Modifier.width(12.dp))
+                    Text(
+                        "Cloudy",
+                        color = Color.White,
+                        fontSize = 32.sp,
+                        fontWeight = FontWeight.Bold
+                    )
                 }
                 Column(horizontalAlignment = Alignment.End) {
-                    Text("25°", color = Color.White, fontSize = 48.sp, fontWeight = FontWeight.Bold)
-                    Text("Feels like 27°", color = Color.White, fontSize = 12.sp)
+                    Text(
+                        "25°",
+                        color = Color.White,
+                        fontSize = 52.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        "Feels like 27°",
+                        color = Color.White,
+                        fontSize = 12.sp,
+                        modifier = Modifier.offset(x = (-10).dp, y = (-10).dp)
+                    )
                 }
             }
             Row(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .padding(horizontal = 24.dp),
-                horizontalArrangement = Arrangement.SpaceBetween
+                horizontalArrangement = Arrangement.SpaceAround
             ) {
                 WeatherInfo("60%", "Humidity")
                 WeatherInfo("10 km/h", "Wind")
@@ -106,8 +127,16 @@ private fun WeatherCard() {
 
 @Composable
 private fun WeatherInfo(value: String, label: String) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.padding(horizontal = 12.dp)) {
-        Text(value, color = Color.White, fontWeight = FontWeight.Bold)
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.padding(horizontal = 12.dp)
+    ) {
+        Text(
+            value,
+            color = Color.White,
+            fontWeight = FontWeight.Bold,
+            fontSize = 20.sp
+        )
         Text(label, color = Color.White, fontSize = 12.sp)
     }
 }


### PR DESCRIPTION
## Summary
- tweak ClassCard temperature badge placement
- match SummaryCard weather widget styling with TypeScript
- remove invalid offset import that broke builds
- fix unresolved offset import and adjust widget spacing

## Testing
- `./gradlew test --no-daemon` *(fails: unable to access gradle-wrapper.jar)*
- `npm test --silent` in `vit-student-app` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_685d8acd0c50832f9c4384f8d892c862