### PR TITLE
Add smooth ViewPager HomeFragment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,4 +45,7 @@ dependencies {
     implementation 'androidx.compose.foundation:foundation'
     implementation 'androidx.compose.material3:material3'
     implementation 'androidx.compose.material:material-icons-extended'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.viewpager2:viewpager2:1.0.0'
+    implementation 'com.google.android.material:material:1.11.0'
 }

--- a/app/src/main/java/com/example/basic/CardAdapter.kt
+++ b/app/src/main/java/com/example/basic/CardAdapter.kt
@@ -1,0 +1,25 @@
+package com.example.basic
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+class CardAdapter(private val items: List<String>) : RecyclerView.Adapter<CardAdapter.CardViewHolder>() {
+
+    class CardViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val text: TextView = itemView.findViewById(R.id.cardText)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CardViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_card, parent, false)
+        return CardViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: CardViewHolder, position: Int) {
+        holder.text.text = items[position]
+    }
+
+    override fun getItemCount(): Int = items.size
+}

--- a/app/src/main/java/com/example/basic/HomeFragment.kt
+++ b/app/src/main/java/com/example/basic/HomeFragment.kt
@@ -1,0 +1,37 @@
+package com.example.basic
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.CompositePageTransformer
+import androidx.viewpager2.widget.MarginPageTransformer
+import androidx.viewpager2.widget.ViewPager2
+import kotlin.math.abs
+
+class HomeFragment : Fragment(R.layout.fragment_home) {
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val viewPager: ViewPager2 = view.findViewById(R.id.viewPager)
+
+        val cards = listOf("Card 1", "Card 2", "Card 3", "Card 4", "Card 5")
+        viewPager.adapter = CardAdapter(cards)
+
+        viewPager.offscreenPageLimit = 3
+
+        val recyclerView = viewPager.getChildAt(0) as RecyclerView
+        recyclerView.setItemViewCacheSize(10)
+        recyclerView.layoutManager?.isItemPrefetchEnabled = true
+
+        val transformer = CompositePageTransformer().apply {
+            addTransformer(MarginPageTransformer(16))
+            addTransformer { page, position ->
+                val r = 1 - abs(position)
+                page.scaleY = 0.85f + r * 0.15f
+            }
+        }
+        viewPager.setPageTransformer(transformer)
+    }
+}

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/viewPager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_card.xml
+++ b/app/src/main/res/layout/item_card.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="200dp"
+    android:layout_margin="16dp"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="4dp">
+
+    <TextView
+        android:id="@+id/cardText"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="Card"
+        android:textSize="18sp" />
+
+</com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## Summary
- implement `HomeFragment` with a tuned ViewPager2 setup for smooth swiping
- add `CardAdapter` for binding sample card data
- include `fragment_home.xml` and `item_card.xml` layouts
- add ConstraintLayout, ViewPager2 and Material dependencies
- fix prefetch call in `HomeFragment`

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_685d8bff99ac832fa84f2fa7e87a02ca