### PR TITLE
Document network permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,10 @@ versions of Gradle.
 
 You can also open the project directory directly in Android Studio and run the
 app on an emulator from there.
+
+## Permissions
+
+The app requires network access to fetch data. The `INTERNET` permission is
+declared in `app/src/main/AndroidManifest.xml`. If you encounter crashes related
+to network requests, verify that this permission is included when merging
+manifests in your build process.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.basic">
-    <!-- Allow the app to make network requests for APIs and images -->
+    <!-- Permission required for network access -->
     <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:allowBackup="true"


### PR DESCRIPTION
## Summary
- document that the app requires `INTERNET` permission
- clarify network permission comment in manifest

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685e5e1adda0832faccce2390476701d