### PR TITLE
Fix unresolved references for food screens

### DIFF
--- a/app/src/main/java/com/example/basic/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/basic/navigation/AppNavHost.kt
@@ -69,7 +69,23 @@ sealed class Screen(
         Icons.Filled.MoreHoriz,
         Icons.Outlined.MoreHoriz
     )
- 
+
+    // Additional screens that are not part of the bottom navigation bar
+    // but still need a route entry for navigation.
+    object FoodSummary : Screen(
+        "foodSummary",
+        "Food Summary",
+        Icons.Filled.Restaurant,
+        Icons.Outlined.Restaurant
+    )
+
+    object MonthlyMenu : Screen(
+        "monthlyMenu",
+        "Monthly Menu",
+        Icons.Filled.Restaurant,
+        Icons.Outlined.Restaurant
+    )
+
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- add missing screen definitions for FoodSummary and MonthlyMenu

## Testing
- `gradle -q :app:assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e67903b20832fb420ae95281707bf