### PR TITLE
Fix monthly menu button ripple area

### DIFF
--- a/app/src/main/java/com/example/basic/FoodMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/FoodMenuScreen.kt
@@ -354,6 +354,7 @@ private fun MonthBar(onClick: () -> Unit, modifier: Modifier = Modifier) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .clickable(onClick = onClick)
                 .padding(vertical = 8.dp, horizontal = 16.dp),
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically
@@ -368,8 +369,7 @@ private fun MonthBar(onClick: () -> Unit, modifier: Modifier = Modifier) {
             Text(
                 text = "View Full Month",
                 color = Color.White,
-                style = MaterialTheme.typography.labelLarge,
-                modifier = Modifier.clickable(onClick = onClick)
+                style = MaterialTheme.typography.labelLarge
             )
         }
     }


### PR DESCRIPTION
## Summary
- fix full month menu ripple effect so entire row is clickable

## Testing
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685e6a8a1f98832f9d0a9eb86cc9ed56