### PR TITLE
Fix layout spacing

### DIFF
--- a/app/src/main/java/com/example/basic/CardCarousel.kt
+++ b/app/src/main/java/com/example/basic/CardCarousel.kt
@@ -42,7 +42,8 @@ fun CardCarousel(
     val config = LocalConfiguration.current
     val screenHeight = config.screenHeightDp.dp
     val cardHeight = screenHeight * 0.7f
-    val numberTop = (screenHeight - cardHeight) / 3f + cardHeight + 20.dp
+    // Position the number row closer to the cards
+    val numberTop = (screenHeight - cardHeight) / 3f + cardHeight - 10.dp
 
     LaunchedEffect(pagerState.currentPage) {
         onIndexChange?.invoke(pagerState.currentPage)

--- a/app/src/main/java/com/example/basic/ClassCard.kt
+++ b/app/src/main/java/com/example/basic/ClassCard.kt
@@ -147,7 +147,9 @@ fun ClassCard(
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .padding(top = 68.dp, end = 24.dp)
+                    // Shift the location text slightly down so it doesn't
+                    // overlap with the weather information
+                    .padding(top = 84.dp, end = 24.dp)
             )
 
             val parts by remember(info.title) {


### PR DESCRIPTION
## Summary
- tweak card carousel page indicator offset
- keep location text from overlapping weather data

## Testing
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685e6f7aa574832fb8e19b5af11a444d