### PR TITLE
Add toggle navigation from Attendance

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceScreen.kt
@@ -24,17 +24,21 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.ToggleOn
+import androidx.compose.material.icons.outlined.ToggleOff
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -42,6 +46,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import com.example.basic.navigation.Screen
 import kotlinx.coroutines.launch
 
 private data class Subject(val name: String, val code: String, val attendance: Int)
@@ -140,10 +146,11 @@ private fun SubjectCard(item: Subject, isLab: Boolean) {
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun AttendanceScreen() {
+fun AttendanceScreen(navController: NavController) {
     val rotate = remember { Animatable(0f) }
     val scale = remember { Animatable(1f) }
     val scope = rememberCoroutineScope()
+    var toggled by remember { mutableStateOf(false) }
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
@@ -190,6 +197,21 @@ fun AttendanceScreen() {
                 contentDescription = "Refresh",
                 tint = Color(0xFF212121),
                 modifier = Modifier.graphicsLayer { rotationZ = rotate.value * 360f }
+            )
+        }
+        IconToggleButton(
+            checked = toggled,
+            onCheckedChange = {
+                toggled = it
+                navController.navigate(Screen.Empty.route)
+            },
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(16.dp)
+        ) {
+            Icon(
+                imageVector = if (toggled) Icons.Filled.ToggleOn else Icons.Outlined.ToggleOff,
+                contentDescription = "Toggle",
             )
         }
     }

--- a/app/src/main/java/com/example/basic/EmptyScreen.kt
+++ b/app/src/main/java/com/example/basic/EmptyScreen.kt
@@ -1,0 +1,24 @@
+package com.example.basic
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun EmptyScreen() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Empty page",
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}

--- a/app/src/main/java/com/example/basic/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/basic/navigation/AppNavHost.kt
@@ -13,6 +13,8 @@ import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.MoreHoriz
 import androidx.compose.material.icons.outlined.Restaurant
+import androidx.compose.material.icons.filled.ToggleOn
+import androidx.compose.material.icons.outlined.ToggleOn
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -33,6 +35,7 @@ import com.example.basic.MonthlyMenuScreen
 import com.example.basic.HomeScreen
 import com.example.basic.MoreScreen
 import com.example.basic.PlannerScreen
+import com.example.basic.EmptyScreen
 
  
 sealed class Screen(
@@ -88,6 +91,13 @@ sealed class Screen(
         Icons.Outlined.Restaurant
     )
 
+    object Empty : Screen(
+        "empty",
+        "Empty",
+        Icons.Filled.ToggleOn,
+        Icons.Outlined.ToggleOn
+    )
+
 }
 
 @Composable
@@ -129,7 +139,7 @@ fun AppNavHost() {
         ) {
             composable(Screen.Home.route) { HomeScreen() }
             composable(Screen.Planner.route) { PlannerScreen() }
-            composable(Screen.Attendance.route) { AttendanceScreen() }
+            composable(Screen.Attendance.route) { AttendanceScreen(navController) }
             composable(Screen.Food.route) {
                 FoodMenuScreen(
                     onShowSummary = { navController.navigate(Screen.FoodSummary.route) },
@@ -143,6 +153,7 @@ fun AppNavHost() {
                 MonthlyMenuScreen(onBack = { navController.popBackStack() })
             }
             composable(Screen.More.route) { MoreScreen() }
+            composable(Screen.Empty.route) { EmptyScreen() }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a reusable `EmptyScreen` placeholder
- add toggle button on the Attendance screen that opens the empty screen
- register the new route in `AppNavHost`

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_685e70056718832fb74b3f1f0dfdc22a