### PR TITLE
Add navigation toggle to empty screen

### DIFF
--- a/app/src/main/java/com/example/basic/EmptyScreen.kt
+++ b/app/src/main/java/com/example/basic/EmptyScreen.kt
@@ -1,0 +1,24 @@
+package com.example.basic
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun EmptyScreen() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Empty page",
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}

--- a/app/src/main/java/com/example/basic/PlannerScreen.kt
+++ b/app/src/main/java/com/example/basic/PlannerScreen.kt
@@ -22,6 +22,13 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ToggleOn
+import androidx.compose.material.icons.outlined.ToggleOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconToggleButton
+import androidx.navigation.NavController
+import com.example.basic.navigation.Screen
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,33 +42,34 @@ import androidx.compose.ui.input.pointer.pointerInput
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalAnimationApi::class)
 @Composable
-fun PlannerScreen() {
+fun PlannerScreen(navController: NavController) {
     val days = WEEKLY_SCHEDULE.keys.toList()
     var dayIndex by remember { mutableStateOf(0) }
     var dragAmount by remember { mutableStateOf(0f) }
     val classes by remember(dayIndex) { derivedStateOf { WEEKLY_SCHEDULE[days[dayIndex]].orEmpty() } }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color(0xFFF0F2F5))
-            .pointerInput(dayIndex) {
-                detectHorizontalDragGestures(
-                    onHorizontalDrag = { _, delta ->
-                        dragAmount += delta
-                    },
-                    onDragEnd = {
-                        if (dragAmount < -100 && dayIndex < days.lastIndex) {
-                            dayIndex++
-                        } else if (dragAmount > 100 && dayIndex > 0) {
-                            dayIndex--
-                        }
-                        dragAmount = 0f
-                    },
-                    onDragCancel = { dragAmount = 0f }
-                )
-            }
-    ) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color(0xFFF0F2F5))
+                .pointerInput(dayIndex) {
+                    detectHorizontalDragGestures(
+                        onHorizontalDrag = { _, delta ->
+                            dragAmount += delta
+                        },
+                        onDragEnd = {
+                            if (dragAmount < -100 && dayIndex < days.lastIndex) {
+                                dayIndex++
+                            } else if (dragAmount > 100 && dayIndex > 0) {
+                                dayIndex--
+                            }
+                            dragAmount = 0f
+                        },
+                        onDragCancel = { dragAmount = 0f }
+                    )
+                }
+        ) {
         Text(
             text = "Weekly Timetable",
             style = MaterialTheme.typography.headlineSmall,
@@ -168,5 +176,23 @@ fun PlannerScreen() {
             }
         }
     }
-}
+    }
+    
+        var toggled by remember { mutableStateOf(false) }
+        IconToggleButton(
+            checked = toggled,
+            onCheckedChange = {
+                toggled = it
+                navController.navigate(Screen.Empty.route)
+            },
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(16.dp)
+        ) {
+            Icon(
+                imageVector = if (toggled) Icons.Filled.ToggleOn else Icons.Outlined.ToggleOff,
+                contentDescription = "Toggle"
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/example/basic/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/basic/navigation/AppNavHost.kt
@@ -12,6 +12,8 @@ import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.MoreHoriz
 import androidx.compose.material.icons.outlined.Restaurant
+import androidx.compose.material.icons.filled.ToggleOn
+import androidx.compose.material.icons.outlined.ToggleOn
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -31,6 +33,7 @@ import com.example.basic.MonthlyMenuScreen
 import com.example.basic.HomeScreen
 import com.example.basic.MoreScreen
 import com.example.basic.PlannerScreen
+import com.example.basic.EmptyScreen
 
  
 sealed class Screen(
@@ -86,6 +89,13 @@ sealed class Screen(
         Icons.Outlined.Restaurant
     )
 
+    object Empty : Screen(
+        "empty",
+        "Empty",
+        Icons.Filled.ToggleOn,
+        Icons.Outlined.ToggleOn
+    )
+
 }
 
 @Composable
@@ -125,7 +135,7 @@ fun AppNavHost() {
             modifier = Modifier.padding(innerPadding)
         ) {
             composable(Screen.Home.route) { HomeScreen() }
-            composable(Screen.Planner.route) { PlannerScreen() }
+            composable(Screen.Planner.route) { PlannerScreen(navController) }
             composable(Screen.Attendance.route) { AttendanceScreen() }
             composable(Screen.Food.route) {
                 FoodMenuScreen(
@@ -140,6 +150,7 @@ fun AppNavHost() {
                 MonthlyMenuScreen(onBack = { navController.popBackStack() })
             }
             composable(Screen.More.route) { MoreScreen() }
+            composable(Screen.Empty.route) { EmptyScreen() }
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose `EmptyScreen` composable for a placeholder page
- extend navigation graph with new route and icons
- overlay planner page with toggle button using `NavController`
- fix missing closing brace in `PlannerScreen`

## Testing
- `./gradlew assembleDebug` *(fails: missing `gradle-wrapper.jar`)*

------
https://chatgpt.com/codex/tasks/task_e_685e6c23c5d4832f940df2efc8c7d75f