### PR TITLE
Add rounded background to meal headers

### DIFF
--- a/vit-student-app/src/screens/MonthlyMenuScreen.tsx
+++ b/vit-student-app/src/screens/MonthlyMenuScreen.tsx
@@ -266,7 +266,14 @@ const styles = StyleSheet.create({
   },
   mealActions: { flexDirection: 'row' },
   iconButton: { marginLeft: 8 },
-  mealTitle: { fontWeight: '600' },
+  mealTitle: {
+    fontWeight: '600',
+    color: '#fff',
+    backgroundColor: '#333',
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 12,
+  },
   mealItems: { color: '#555' },
   pastDay: { opacity: 0.5 },
 });


### PR DESCRIPTION
## Summary
- tweak the MonthlyMenuScreen meal title style to have dark rounded background

## Testing
- `./gradlew test` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_685e7227d344832fbe7ac9e9ae6164af