### PR TITLE
Add attendance details placeholder screen

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceDetailsScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceDetailsScreen.kt
@@ -1,0 +1,26 @@
+package com.example.basic
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun AttendanceDetailsScreen(onBack: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "Attendance details page coming soon.",
+            style = MaterialTheme.typography.bodyLarge
+        )
+        Button(onClick = onBack) { Text("Back") }
+    }
+}

--- a/app/src/main/java/com/example/basic/AttendanceScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Button
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -140,7 +141,7 @@ private fun SubjectCard(item: Subject, isLab: Boolean) {
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun AttendanceScreen() {
+fun AttendanceScreen(onShowDetails: () -> Unit = {}) {
     val rotate = remember { Animatable(0f) }
     val scale = remember { Animatable(1f) }
     val scope = rememberCoroutineScope()
@@ -162,6 +163,14 @@ fun AttendanceScreen() {
                     SubjectCard(item = item, isLab = index >= subjects.size - 4)
                 }
             }
+        }
+        Button(
+            onClick = onShowDetails,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 24.dp)
+        ) {
+            Text("More Details")
         }
         FloatingActionButton(
             onClick = {

--- a/app/src/main/java/com/example/basic/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/basic/navigation/AppNavHost.kt
@@ -30,6 +30,7 @@ import com.example.basic.AttendanceScreen
 import com.example.basic.FoodMenuScreen
 import com.example.basic.FoodSummaryScreen
 import com.example.basic.MonthlyMenuScreen
+import com.example.basic.AttendanceDetailsScreen
 import com.example.basic.HomeScreen
 import com.example.basic.MoreScreen
 import com.example.basic.PlannerScreen
@@ -88,6 +89,13 @@ sealed class Screen(
         Icons.Outlined.Fastfood
     )
 
+    object AttendanceDetails : Screen(
+        "attendanceDetails",
+        "Attendance Details",
+        Icons.Filled.CheckCircle,
+        Icons.Outlined.CheckCircle
+    )
+
 }
 
 @Composable
@@ -129,7 +137,9 @@ fun AppNavHost() {
         ) {
             composable(Screen.Home.route) { HomeScreen() }
             composable(Screen.Planner.route) { PlannerScreen() }
-            composable(Screen.Attendance.route) { AttendanceScreen() }
+            composable(Screen.Attendance.route) {
+                AttendanceScreen(onShowDetails = { navController.navigate(Screen.AttendanceDetails.route) })
+            }
             composable(Screen.Food.route) {
                 FoodMenuScreen(
                     onShowSummary = { navController.navigate(Screen.FoodSummary.route) },
@@ -141,6 +151,9 @@ fun AppNavHost() {
             }
             composable(Screen.MonthlyMenu.route) {
                 MonthlyMenuScreen(onBack = { navController.popBackStack() })
+            }
+            composable(Screen.AttendanceDetails.route) {
+                AttendanceDetailsScreen(onBack = { navController.popBackStack() })
             }
             composable(Screen.More.route) { MoreScreen() }
         }


### PR DESCRIPTION
## Summary
- add a placeholder AttendanceDetailsScreen
- add new route in AppNavHost and wire button to it
- show new "More Details" button at bottom of AttendanceScreen

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685e7174cee8832f8c50f409151da0ca