### PR TITLE
Add responsive layout wrapper

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,11 @@
         android:roundIcon="@android:drawable/ic_menu_gallery"
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.Light.NoActionBar">
-        <activity android:name=".MainActivity" android:exported="true" android:hardwareAccelerated="true">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:hardwareAccelerated="true"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/com/example/basic/MainActivity.kt
+++ b/app/src/main/java/com/example/basic/MainActivity.kt
@@ -5,13 +5,16 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import com.example.basic.navigation.AppNavHost
 import com.example.basic.ui.theme.VitStudentAppTheme
+import com.example.basic.ScaledLayout
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             VitStudentAppTheme {
-                AppNavHost()
+                ScaledLayout {
+                    AppNavHost()
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/basic/ResponsiveLayout.kt
+++ b/app/src/main/java/com/example/basic/ResponsiveLayout.kt
@@ -1,0 +1,41 @@
+package com.example.basic
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlin.math.min
+
+/**
+ * Scales the provided [content] so it maintains the same aspect ratio on all
+ * screen sizes. The layout uses [designWidth] and [designHeight] as the base
+ * dimensions of the UI and scales the content uniformly to fit within the
+ * available space.
+ */
+@Composable
+fun ScaledLayout(
+    designWidth: Dp = 360.dp,
+    designHeight: Dp = 640.dp,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    BoxWithConstraints(Modifier.fillMaxSize()) {
+        val scale = min(maxWidth / designWidth, maxHeight / designHeight)
+        Box(
+            modifier = Modifier
+                .size(designWidth, designHeight)
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                }
+                .align(Alignment.Center),
+            content = content
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- ensure a fixed aspect ratio by scaling content in `ScaledLayout`
- wrap the entire UI in `ScaledLayout`
- restrict orientation to portrait

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e71be85bc832f8b2677a33c2043d0