### PR TITLE
Add Attendance2 screen and button

### DIFF
--- a/vit-student-app/App.tsx
+++ b/vit-student-app/App.tsx
@@ -29,6 +29,7 @@ import AttendanceScreen from './src/screens/Attendance';
 import MoreRootScreen from './src/screens/MoreRootScreen';
 import GalleryScreen from './src/screens/GalleryScreen';
 import Profile from './src/screens/Profile';
+import Attendance2 from './src/screens/Attendance2';
 import { UserProvider } from './src/context/UserContext';
 
 type RootStackParamList = {
@@ -37,6 +38,7 @@ type RootStackParamList = {
   MonthlyMenuScreen: undefined;
   FoodSummaryScreen: undefined;
   Profile: undefined;
+  Attendance2: undefined;
 };
 
 type TabParamList = {
@@ -130,6 +132,7 @@ export default function App() {
             name="FoodSummaryScreen"
             component={FoodSummaryScreen}
           />
+          <RootStack.Screen name="Attendance2" component={Attendance2} />
           <RootStack.Screen name="Profile" component={Profile} />
           </RootStack.Navigator>
         </NavigationContainer>

--- a/vit-student-app/src/screens/Attendance2.tsx
+++ b/vit-student-app/src/screens/Attendance2.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function Attendance2() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Attendance 2</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#fff' },
+  text: { fontSize: 24, fontWeight: '700', color: '#333' },
+});

--- a/vit-student-app/src/screens/Planner.tsx
+++ b/vit-student-app/src/screens/Planner.tsx
@@ -12,6 +12,7 @@ import {
   GestureResponderEvent,
   PanResponderGestureState,
 } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 import { WEEKLY_SCHEDULE, ClassEntry } from '../data/weeklySchedule';
 
 const DAYS = Object.keys(WEEKLY_SCHEDULE);
@@ -20,6 +21,7 @@ export default function Planner() {
   const [index, setIndex] = useState<number>(0);
   const day = DAYS[index];
   const classes: ClassEntry[] = WEEKLY_SCHEDULE[day];
+  const navigation = useNavigation();
 
   const pan = useRef(
     PanResponder.create({
@@ -97,6 +99,12 @@ export default function Planner() {
           </TouchableOpacity>
         ))}
       </ScrollView>
+      <TouchableOpacity
+        style={styles.attendanceBtn}
+        onPress={() => navigation.navigate('Attendance2' as never)}
+      >
+        <Text style={styles.attendanceBtnText}>Attendance 2</Text>
+      </TouchableOpacity>
     </SafeAreaView>
   );
 }
@@ -146,4 +154,14 @@ const styles = StyleSheet.create({
   classRight: { justifyContent: 'space-between', alignItems: 'flex-end' },
   timeText: { fontSize: 12, color: '#333' },
   roomText: { fontSize: 10, color: '#666', marginTop: 2 },
+  attendanceBtn: {
+    position: 'absolute',
+    bottom: 24,
+    left: 24,
+    backgroundColor: '#6C5CE7',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 24,
+  },
+  attendanceBtnText: { color: '#fff', fontWeight: '600' },
 });


### PR DESCRIPTION
## Summary
- create an empty `Attendance2` page
- wire the new page into the stack navigator
- add button on Planner screen to open Attendance2 page

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access gradle-wrapper.jar)*
- `npx tsc --noEmit` *(fails: cannot use JSX without the '--jsx' flag)*

------
https://chatgpt.com/codex/tasks/task_e_685e727358b0832fb716ef222b63c7a5