### PR TITLE
Add placeholder page toggle from planner

### DIFF
--- a/vit-student-app/App.tsx
+++ b/vit-student-app/App.tsx
@@ -18,6 +18,7 @@ import FoodMenuScreen from './src/screens/FoodMenuScreen';
 import MonthlyMenuScreen from './src/screens/MonthlyMenuScreen';
 import FoodSummaryScreen from './src/screens/FoodSummaryScreen';
 import PlannerScreen from './src/screens/Planner';
+import PlannerDetailScreen from './src/screens/PlannerDetailScreen';
 
 // Component for the Attendance tab
 import AttendanceScreen from './src/screens/Attendance';
@@ -38,6 +39,7 @@ type RootStackParamList = {
   MonthlyMenuScreen: undefined;
   FoodSummaryScreen: undefined;
   Profile: undefined;
+  PlannerDetailScreen: undefined;
 };
 
 type TabParamList = {
@@ -140,6 +142,10 @@ export default function App() {
             component={FoodSummaryScreen}
           />
           <RootStack.Screen name="Profile" component={Profile} />
+          <RootStack.Screen
+            name="PlannerDetailScreen"
+            component={PlannerDetailScreen}
+          />
           </RootStack.Navigator>
         </NavigationContainer>
       </UserProvider>

--- a/vit-student-app/src/screens/Planner.tsx
+++ b/vit-student-app/src/screens/Planner.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from 'react';
+import { useNavigation } from '@react-navigation/native';
 import {
   SafeAreaView,
   View,
@@ -17,6 +18,7 @@ import { WEEKLY_SCHEDULE, ClassEntry } from '../data/weeklySchedule';
 const DAYS = Object.keys(WEEKLY_SCHEDULE);
 
 export default function Planner() {
+  const navigation = useNavigation();
   const [index, setIndex] = useState<number>(0);
   const day = DAYS[index];
   const classes: ClassEntry[] = WEEKLY_SCHEDULE[day];
@@ -97,6 +99,13 @@ export default function Planner() {
           </TouchableOpacity>
         ))}
       </ScrollView>
+
+      <TouchableOpacity
+        style={styles.detailButton}
+        onPress={() => navigation.navigate('PlannerDetailScreen' as never)}
+      >
+        <Text style={styles.detailButtonText}>Open Planner Details</Text>
+      </TouchableOpacity>
     </SafeAreaView>
   );
 }
@@ -146,4 +155,12 @@ const styles = StyleSheet.create({
   classRight: { justifyContent: 'space-between', alignItems: 'flex-end' },
   timeText: { fontSize: 12, color: '#333' },
   roomText: { fontSize: 10, color: '#666', marginTop: 2 },
+  detailButton: {
+    margin: 16,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: '#6C5CE7',
+    alignItems: 'center',
+  },
+  detailButtonText: { color: '#fff', fontWeight: '600' },
 });

--- a/vit-student-app/src/screens/PlannerDetailScreen.tsx
+++ b/vit-student-app/src/screens/PlannerDetailScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, Platform, StatusBar } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+export default function PlannerDetailScreen() {
+  return (
+    <SafeAreaView
+      style={[
+        styles.container,
+        { paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 },
+      ]}
+    >
+      <View style={styles.inner}>
+        <Text style={styles.text}>Planner detail page placeholder</Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  inner: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  text: { fontSize: 18, color: '#333' },
+});


### PR DESCRIPTION
## Summary
- create a new `PlannerDetailScreen` placeholder screen
- show a button on Planner screen that navigates to the placeholder
- register the new screen in navigation stack

## Testing
- `npm --prefix vit-student-app test --silent`
- `npx --prefix vit-student-app tsc -p vit-student-app/tsconfig.json --noEmit` *(fails: tsc not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e74f8577c832f9d3d143eeeeb7ea2