### PR TITLE
Add chip style to meal names

### DIFF
--- a/vit-student-app/src/screens/MonthlyMenuScreen.tsx
+++ b/vit-student-app/src/screens/MonthlyMenuScreen.tsx
@@ -266,7 +266,14 @@ const styles = StyleSheet.create({
   },
   mealActions: { flexDirection: 'row' },
   iconButton: { marginLeft: 8 },
-  mealTitle: { fontWeight: '600' },
+  mealTitle: {
+    fontWeight: '600',
+    color: '#fff',
+    backgroundColor: '#333',
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 12,
+  },
   mealItems: { color: '#555' },
   pastDay: { opacity: 0.5 },
 });


### PR DESCRIPTION
## Summary
- apply dark background chip style for meal titles on the monthly menu screen

## Testing
- `npm install --silent`
- `npx tsc --noEmit` *(fails: Type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_685e76ba1d84832fae08640eed75039b