### PR TITLE
Add calender placeholder screen

### DIFF
--- a/vit-student-app/App.tsx
+++ b/vit-student-app/App.tsx
@@ -18,6 +18,7 @@ import FoodMenuScreen from './src/screens/FoodMenuScreen';
 import MonthlyMenuScreen from './src/screens/MonthlyMenuScreen';
 import FoodSummaryScreen from './src/screens/FoodSummaryScreen';
 import PlannerScreen from './src/screens/Planner';
+import CalenderScreen from './src/screens/CalenderScreen';
 
 // Component for the Attendance tab
 import AttendanceScreen from './src/screens/Attendance';
@@ -38,6 +39,7 @@ type RootStackParamList = {
   MonthlyMenuScreen: undefined;
   FoodSummaryScreen: undefined;
   Profile: undefined;
+  CalenderScreen: undefined;
 };
 
 type TabParamList = {
@@ -140,6 +142,7 @@ export default function App() {
             component={FoodSummaryScreen}
           />
           <RootStack.Screen name="Profile" component={Profile} />
+          <RootStack.Screen name="CalenderScreen" component={CalenderScreen} />
           </RootStack.Navigator>
         </NavigationContainer>
       </UserProvider>

--- a/vit-student-app/src/screens/CalenderScreen.tsx
+++ b/vit-student-app/src/screens/CalenderScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, Platform, StatusBar } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+export default function CalenderScreen() {
+  return (
+    <SafeAreaView
+      style={[
+        styles.container,
+        { paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 },
+      ]}
+    >
+      <View style={styles.inner}>
+        <Text style={styles.text}>Calender page placeholder</Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  inner: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  text: { fontSize: 18, color: '#333' },
+});

--- a/vit-student-app/src/screens/Planner.tsx
+++ b/vit-student-app/src/screens/Planner.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from 'react';
+import { useNavigation } from '@react-navigation/native';
 import {
   SafeAreaView,
   View,
@@ -20,6 +21,7 @@ export default function Planner() {
   const [index, setIndex] = useState<number>(0);
   const day = DAYS[index];
   const classes: ClassEntry[] = WEEKLY_SCHEDULE[day];
+  const navigation = useNavigation();
 
   const pan = useRef(
     PanResponder.create({
@@ -97,6 +99,13 @@ export default function Planner() {
           </TouchableOpacity>
         ))}
       </ScrollView>
+
+      <TouchableOpacity
+        style={styles.calenderButton}
+        onPress={() => navigation.navigate('CalenderScreen' as never)}
+      >
+        <Text style={styles.calenderButtonText}>Open Calender</Text>
+      </TouchableOpacity>
     </SafeAreaView>
   );
 }
@@ -146,4 +155,12 @@ const styles = StyleSheet.create({
   classRight: { justifyContent: 'space-between', alignItems: 'flex-end' },
   timeText: { fontSize: 12, color: '#333' },
   roomText: { fontSize: 10, color: '#666', marginTop: 2 },
+  calenderButton: {
+    margin: 16,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: '#6C5CE7',
+    alignItems: 'center',
+  },
+  calenderButtonText: { color: '#fff', fontWeight: '600' },
 });


### PR DESCRIPTION
## Summary
- add CalenderScreen placeholder for React Native app
- navigate to CalenderScreen from Planner page
- register CalenderScreen in app stack

## Testing
- `npm test` *(fails: Missing script)*
- `./gradlew test` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_685e76e4515c832fbffb5384b2057a2e