### PR TITLE
Add chip style to meal names

### DIFF
--- a/vit-student-app/src/screens/MonthlyMenuScreen.tsx
+++ b/vit-student-app/src/screens/MonthlyMenuScreen.tsx
@@ -149,7 +149,9 @@ export default function MonthlyMenuScreen() {
           return (
             <View key={key} style={styles.mealItem}>
               <View style={styles.mealHeader}>
-                <Text style={styles.mealTitle}>{m.name}</Text>
+                <View style={styles.mealTitleContainer}>
+                  <Text style={styles.mealTitle}>{m.name}</Text>
+                </View>
                 <View style={styles.mealActions}>
                   <Pressable
                     onPress={() => toggleLike(key)}
@@ -266,7 +268,16 @@ const styles = StyleSheet.create({
   },
   mealActions: { flexDirection: 'row' },
   iconButton: { marginLeft: 8 },
-  mealTitle: { fontWeight: '600' },
+  mealTitleContainer: {
+    backgroundColor: '#333',
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 12,
+  },
+  mealTitle: {
+    fontWeight: '600',
+    color: '#fff',
+  },
   mealItems: { color: '#555' },
   pastDay: { opacity: 0.5 },
 });


### PR DESCRIPTION
## Summary
- style meal headings in the monthly menu with a chip-like dark background

## Testing
- `npm install --silent`
- `npx tsc --noEmit` *(fails: existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685e76ba1d84832fae08640eed75039b