### PR TITLE
Add calender placeholder screen

### DIFF
--- a/vit-student-app/App.tsx
+++ b/vit-student-app/App.tsx
@@ -18,6 +18,7 @@ import FoodMenuScreen from './src/screens/FoodMenuScreen';
 import MonthlyMenuScreen from './src/screens/MonthlyMenuScreen';
 import FoodSummaryScreen from './src/screens/FoodSummaryScreen';
 import PlannerScreen from './src/screens/Planner';
+import CalenderScreen from './src/screens/CalenderScreen';
 
 // Component for the Attendance tab
 import AttendanceScreen from './src/screens/Attendance';
@@ -38,6 +39,7 @@ type RootStackParamList = {
   MonthlyMenuScreen: undefined;
   FoodSummaryScreen: undefined;
   Profile: undefined;
+  CalenderScreen: undefined;
 };
 
 type TabParamList = {
@@ -140,6 +142,7 @@ export default function App() {
             component={FoodSummaryScreen}
           />
           <RootStack.Screen name="Profile" component={Profile} />
+          <RootStack.Screen name="CalenderScreen" component={CalenderScreen} />
           </RootStack.Navigator>
         </NavigationContainer>
       </UserProvider>

--- a/vit-student-app/src/screens/CalenderScreen.tsx
+++ b/vit-student-app/src/screens/CalenderScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, Platform, StatusBar } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+export default function CalenderScreen() {
+  return (
+    <SafeAreaView
+      style={[
+        styles.container,
+        { paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 },
+      ]}
+    >
+      <View style={styles.inner}>
+        <Text style={styles.text}>Calender page placeholder</Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  inner: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  text: { fontSize: 18, color: '#333' },
+});

--- a/vit-student-app/src/screens/Planner.tsx
+++ b/vit-student-app/src/screens/Planner.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from 'react';
+import { useNavigation } from '@react-navigation/native';
 import {
   SafeAreaView,
   View,
@@ -20,6 +21,7 @@ export default function Planner() {
   const [index, setIndex] = useState<number>(0);
   const day = DAYS[index];
   const classes: ClassEntry[] = WEEKLY_SCHEDULE[day];
+  const navigation = useNavigation();
 
   const pan = useRef(
     PanResponder.create({
@@ -51,7 +53,15 @@ export default function Planner() {
         { paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 },
       ]}
     >
-      <Text style={styles.heading}>Weekly Timetable</Text>
+      <View style={styles.headerRow}>
+        <Text style={styles.heading}>Weekly Timetable</Text>
+        <TouchableOpacity
+          style={styles.calenderButton}
+          onPress={() => navigation.navigate('CalenderScreen' as never)}
+        >
+          <Text style={styles.calenderButtonText}>Calender</Text>
+        </TouchableOpacity>
+      </View>
 
       <ScrollView
         horizontal
@@ -97,6 +107,7 @@ export default function Planner() {
           </TouchableOpacity>
         ))}
       </ScrollView>
+
     </SafeAreaView>
   );
 }
@@ -106,9 +117,14 @@ const styles = StyleSheet.create({
   heading: {
     fontSize: 22,
     fontWeight: '700',
-    marginVertical: 16,
-    marginHorizontal: 16,
     color: '#333',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginHorizontal: 16,
+    marginVertical: 16,
   },
   dayRow: {
     flexGrow: 0,
@@ -146,4 +162,11 @@ const styles = StyleSheet.create({
   classRight: { justifyContent: 'space-between', alignItems: 'flex-end' },
   timeText: { fontSize: 12, color: '#333' },
   roomText: { fontSize: 10, color: '#666', marginTop: 2 },
+  calenderButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    backgroundColor: '#6C5CE7',
+  },
+  calenderButtonText: { color: '#fff', fontWeight: '600' },
 });


### PR DESCRIPTION
## Summary
- add CalenderScreen placeholder for React Native app
- navigate to CalenderScreen from Planner page
- register CalenderScreen in app stack
- move the Calender button to the Planner header so it appears top-right

## Testing
- `npm test` *(fails: Missing script)*
- `./gradlew test` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_685e76e4515c832fbffb5384b2057a2e