### PR TITLE
Revamp schedule details view

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceDetailsScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceDetailsScreen.kt
@@ -12,9 +12,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -43,7 +40,9 @@ import androidx.compose.animation.with
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.runtime.rememberCoroutineScope
-import com.example.basic.WEEKLY_SCHEDULE
+import com.example.basic.PlannerRepository
+import com.example.basic.DaySchedule
+import com.example.basic.ClassEntry
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -51,55 +50,13 @@ import java.time.LocalTime
 import java.time.format.TextStyle
 import java.util.Locale
 
-private enum class EventCategory(val label: String, val color: Color) {
-    Personal("Personal", Color(0xFF4CAF50)),
-    Shopping("Shopping", Color(0xFFFF9800)),
-    Todo("To do", Color(0xFF9C27B0)),
-    Event("Event", Color(0xFFE91E63)),
-    Birthday("Birthday", Color(0xFFD32F2F))
-}
 
-private data class ClassEvent(
-    val start: String,
-    val end: String,
-    val course: String,
-    val code: String,
-    val room: String,
-    val category: EventCategory
-)
-
-private data class DaySchedule(val date: LocalDate, val events: List<ClassEvent>)
-
-private fun plannerSchedules(): List<DaySchedule> {
-    val start = LocalDate.now().with(java.time.DayOfWeek.MONDAY)
-    return WEEKLY_SCHEDULE.entries.mapIndexed { index, entry ->
-        val events = entry.value.map {
-            ClassEvent(
-                start = it.start,
-                end = it.end,
-                course = it.course,
-                code = it.course,
-                room = it.room,
-                category = EventCategory.Personal
-            )
-        }
-        DaySchedule(start.plusDays(index.toLong()), events)
-    }
-}
-
-private object PlannerRepository {
-    private val schedules = plannerSchedules()
-    fun getTodayClasses(date: LocalDate): List<ClassEvent> {
-        return schedules.firstOrNull { it.date.dayOfWeek == date.dayOfWeek }?.events ?: emptyList()
-
-    }
-}
 
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalAnimationApi::class)
 @Composable
 fun AttendanceDetailsScreen(onBack: () -> Unit) {
-    val days = remember { plannerSchedules() }
+    val days = remember { PlannerRepository.weekSchedule() }
     var selected by remember { mutableStateOf(0) }
     val coroutineScope = rememberCoroutineScope()
     val listState = rememberLazyListState()
@@ -172,7 +129,7 @@ fun AttendanceDetailsScreen(onBack: () -> Unit) {
                 label = "schedule"
             ) { index ->
                 val selectedDate = days[index].date
-                val classes = PlannerRepository.getTodayClasses(selectedDate)
+                val classes = PlannerRepository.getClasses(selectedDate)
                 Column {
                     CurrentDayHeader(selectedDate)
                     ScheduleList(date = selectedDate, events = classes)
@@ -196,15 +153,16 @@ private fun DaySelector(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .background(Color(0xFFF7F7F7))
-            .height(52.dp)
-            .padding(start = 16.dp, end = 16.dp),
+            .background(Color(0xFFFAFAFA))
+            .height(64.dp)
+            .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
-            month,
+            text = month,
             fontWeight = FontWeight.Bold,
-            color = Color.Gray,
+            color = Color(0xFF424242),
+            style = MaterialTheme.typography.bodyMedium,
             modifier = Modifier.padding(end = 8.dp)
         )
         LazyRow(
@@ -215,29 +173,22 @@ private fun DaySelector(
         ) {
             itemsIndexed(days) { index, day ->
                 val isSelected = index == selected
-                val textColor = if (isSelected) Color.White else Color.LightGray
-                val bgColor = if (isSelected) Color(0xFF1E88E5) else Color.Transparent
-                val shape = RoundedCornerShape(12.dp)
-                Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier
-                    .clip(shape)
-                    .clickable { onSelect(index) }
-                    .background(bgColor)
-                    .padding(horizontal = 12.dp, vertical = 4.dp)
-                    .shadow(if (isSelected) 4.dp else 0.dp, shape)
-            ) {
-                Text(
-                    day.date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
-                    color = textColor,
-                    fontSize = 12.sp,
-                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal
-                )
-                Text(
-                    day.date.dayOfMonth.toString(),
-                    color = textColor,
-                    fontSize = 12.sp
-                )
+                val bgColor = if (isSelected) Color(0xFF2979FF) else Color(0xFFF5F5F5)
+                val textColor = if (isSelected) Color.White else Color(0xFF424242)
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(8.dp))
+                        .clickable { onSelect(index) }
+                        .background(bgColor)
+                        .padding(horizontal = 12.dp, vertical = 6.dp)
+                ) {
+                    Text(
+                        text = "${day.date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault())} ${day.date.dayOfMonth}",
+                        color = textColor,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
             }
         }
     }
@@ -248,9 +199,8 @@ private fun DaySelector(
 private fun CurrentDayHeader(date: LocalDate) {
     Text(
         text = date.format(java.time.format.DateTimeFormatter.ofPattern("EEEE d")),
-        fontSize = 20.sp,
-        fontWeight = FontWeight.Medium,
         color = Color(0xFF757575),
+        style = MaterialTheme.typography.bodyMedium,
         modifier = Modifier
             .fillMaxWidth()
             .padding(start = 16.dp, top = 16.dp)
@@ -258,23 +208,13 @@ private fun CurrentDayHeader(date: LocalDate) {
 }
 
 @Composable
-private fun ScheduleList(date: LocalDate, events: List<ClassEvent>) {
-    val density = LocalDensity.current
-    val lineX = with(density) { 32.dp.toPx() }
+private fun ScheduleList(date: LocalDate, events: List<ClassEntry>) {
     val now = LocalDateTime.now()
 
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 16.dp)
-            .drawBehind {
-                drawLine(
-                    color = Color.LightGray,
-                    start = Offset(lineX, 0f),
-                    end = Offset(lineX, size.height),
-                    strokeWidth = with(density) { 1.dp.toPx() }
-                )
-            },
+            .padding(horizontal = 16.dp),
         contentPadding = PaddingValues(vertical = 8.dp)
     ) {
         itemsIndexed(events) { index, event ->
@@ -282,7 +222,6 @@ private fun ScheduleList(date: LocalDate, events: List<ClassEvent>) {
             val end = LocalTime.parse(event.end)
             val startDateTime = date.atTime(start)
             val endDateTime = date.atTime(end)
-            val isPast = endDateTime.isBefore(now)
             val isCurrent = now.isAfter(startDateTime) && now.isBefore(endDateTime)
 
             val infinite = rememberInfiniteTransition()
@@ -303,31 +242,33 @@ private fun ScheduleList(date: LocalDate, events: List<ClassEvent>) {
                     horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = Modifier.width(64.dp)
                 ) {
-                    // Display only the start time on the timeline
-                    Text(event.start, color = Color.Gray, fontSize = 12.sp)
-                    val fillColor = when {
-                        isCurrent -> Color(0xFF1E88E5)
-                        isPast -> Color(0xFFD32F2F)
-                        else -> Color.Transparent
+                    Text(event.start, color = Color.Gray, style = MaterialTheme.typography.bodyMedium)
+                    Canvas(modifier = Modifier.height(32.dp).width(16.dp)) {
+                        val centerX = size.width / 2
+                        val radius = 8.dp.toPx()
+                        val lineGap = 1.dp.toPx()
+                        if (index > 0) {
+                            drawLine(
+                                color = Color(0xFF2979FF),
+                                start = Offset(centerX, 0f),
+                                end = Offset(centerX, size.height / 2 - radius - lineGap),
+                                strokeWidth = 4f
+                            )
+                        }
+                        if (index < events.lastIndex) {
+                            drawLine(
+                                color = Color(0xFF2979FF),
+                                start = Offset(centerX, size.height / 2 + radius + lineGap),
+                                end = Offset(centerX, size.height),
+                                strokeWidth = 4f
+                            )
+                        }
+                        drawCircle(
+                            color = Color(0xFF2979FF),
+                            radius = radius,
+                            center = Offset(centerX, size.height / 2)
+                        )
                     }
-                    val borderColor = when {
-                        isCurrent -> Color(0xFF1E88E5)
-                        isPast -> Color(0xFFD32F2F)
-                        else -> Color.LightGray
-                    }
-                    Box(
-                        modifier = Modifier
-                            .size(10.dp)
-                            .graphicsLayer {
-                                if (isCurrent) {
-                                    scaleX = pulse
-                                    scaleY = pulse
-                                }
-                            }
-                            .clip(CircleShape)
-                            .background(fillColor)
-                            .border(2.dp, borderColor, CircleShape)
-                    )
                 }
                 Spacer(modifier = Modifier.width(8.dp))
                 EventCard(event)
@@ -337,24 +278,52 @@ private fun ScheduleList(date: LocalDate, events: List<ClassEvent>) {
 }
 
 @Composable
-private fun EventCard(event: ClassEvent) {
+private fun EventCard(event: ClassEntry) {
     Card(
         shape = RoundedCornerShape(12.dp),
-        colors = CardDefaults.cardColors(containerColor = event.category.color),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp)
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(event.course, color = Color.White, fontWeight = FontWeight.Bold)
-                Text(event.category.label, color = Color.White.copy(alpha = 0.9f), fontSize = 12.sp)
+        Column {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color(0xFF4CAF50))
+                    .padding(horizontal = 12.dp, vertical = 4.dp)
+            ) {
+                Column {
+                    Text(
+                        text = "${event.start} – ${event.end}",
+                        color = Color.White,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Text(
+                        text = event.course,
+                        color = Color.White,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = event.faculty,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(
+                    text = event.room,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.Gray
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/basic/PlannerRepository.kt
+++ b/app/src/main/java/com/example/basic/PlannerRepository.kt
@@ -1,0 +1,25 @@
+package com.example.basic
+
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.format.TextStyle
+import java.util.Locale
+
+data class DaySchedule(val date: LocalDate, val events: List<ClassEntry>)
+
+object PlannerRepository {
+    private fun dayKey(day: DayOfWeek): String {
+        return day.getDisplayName(TextStyle.FULL, Locale.getDefault())
+    }
+
+    fun getClasses(date: LocalDate): List<ClassEntry> {
+        val key = dayKey(date.dayOfWeek)
+        return WEEKLY_SCHEDULE[key].orEmpty()
+    }
+
+    fun weekSchedule(start: LocalDate = LocalDate.now().with(DayOfWeek.MONDAY)): List<DaySchedule> {
+        return WEEKLY_SCHEDULE.entries.mapIndexed { index, entry ->
+            DaySchedule(start.plusDays(index.toLong()), entry.value)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add shared `PlannerRepository` for weekly schedule data
- redesign date selector with accessible colors
- replace mock model with `ClassEntry` and show times on cards
- update timeline markers with blue circle and segments

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e920f967c832fa53f4c763ada976f