### PR TITLE
Home screen redesign

### DIFF
--- a/app/src/main/java/com/example/basic/HomeScreen.kt
+++ b/app/src/main/java/com/example/basic/HomeScreen.kt
@@ -1,187 +1,196 @@
 package com.example.basic
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Fastfood
 import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.launch
-
-enum class PanelState { None, Top, Bottom }
+import androidx.compose.ui.unit.sp
+import com.example.basic.ui.theme.accentBlue
+import com.example.basic.ui.theme.accentOrange
+import com.example.basic.ui.theme.homeSectionBg
 
 @Composable
 fun HomeScreen() {
-    val baseCards = listOf(
-        ClassInfo("1", "ECE1001 @ Lab 3", "08:00 – 08:50"),
-        ClassInfo("2", "MAT1002 @ Room 105", "09:00 – 09:50"),
-        ClassInfo("3", "PHY1003 @ Hall A", "10:00 – 10:50"),
-        ClassInfo("4", "CHE1004 @ Lab 2", "11:00 – 11:50"),
-        ClassInfo("5", "CSE1005 @ Room 201", "12:00 – 12:50"),
-    )
-    val cards = listOf(ClassInfo("overview", "", "")) + baseCards
-    var panel by remember { mutableStateOf(PanelState.None) }
+    val timetable = remember {
+        listOf(
+            TimetableEntry("DSA", "Dr. Smith", "301", "1.0 h", "08:00 – 09:00"),
+            TimetableEntry("Algorithms", "Prof. Rao", "204", "1.0 h", "09:15 – 10:15"),
+            TimetableEntry("Networks", "Ms. Clark", "Lab 2", "1.0 h", "10:30 – 11:30")
+        )
+    }
+    val meals = remember {
+        listOf(
+            "Breakfast" to "Pancakes",
+            "Lunch" to "Chicken Salad",
+            "Snacks" to "Fruit & Yogurt",
+            "Dinner" to "Salmon"
+        )
+    }
+    val tasks = remember {
+        listOf(
+            "Finish report" to "Complete Q3 analysis",
+            "Grocery shopping" to "Buy veggies and milk",
+            "Call plumber" to "Fix kitchen sink leak"
+        )
+    }
 
-    Box(
+    Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color(0xFFF0F0F0))
+            .background(Color.White)
+            .verticalScroll(rememberScrollState())
     ) {
- 
-        CardCarousel(
-            cards = cards,
-            onSwipeDown = {
-                if (panel == PanelState.None) panel = PanelState.Top
-                else if (panel == PanelState.Bottom) panel = PanelState.None
-            },
-            onSwipeUp = {
-                if (panel == PanelState.None) panel = PanelState.Bottom
-                else if (panel == PanelState.Top) panel = PanelState.None
-            },
-            locationName = "Amaravati"
-        )
- 
+        GreetingBar(firstName = "Alex")
+        Spacer(Modifier.height(8.dp))
+        WeatherCard(modifier = Modifier.padding(horizontal = 16.dp))
+        Spacer(Modifier.height(16.dp))
 
-        if (panel != PanelState.None) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color(0x66000000))
-                    .clickable { panel = PanelState.None }
-            )
+        SectionBox(icon = "\uD83D\uDD52", title = "Today's Timetable") {
+            timetable.forEachIndexed { i, item ->
+                TimetableItem(item)
+                if (i != timetable.lastIndex) Spacer(Modifier.height(8.dp))
+            }
         }
 
-        AnimatedVisibility(
-            visible = panel == PanelState.Top,
-            enter = slideInVertically(initialOffsetY = { -it }, animationSpec = tween(150)),
-            exit = slideOutVertically(targetOffsetY = { -it }, animationSpec = tween(150))
-        ) {
-            WhatsNextPanel(onDismiss = { panel = PanelState.None })
-        }
+        Spacer(Modifier.height(16.dp))
 
-        AnimatedVisibility(
-            visible = panel == PanelState.Bottom,
-            enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(150)),
-            exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(150))
-        ) {
-            BottomPanel(onDismiss = { panel = PanelState.None })
-        }
-    }
-}
-
-@Composable
-private fun WhatsNextPanel(onDismiss: () -> Unit) {
-    Surface(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(250.dp),
-        shadowElevation = 8.dp,
-        color = Color.White
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp)
-        ) {
-            Text(
-                "What’s Next",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold
-            )
-            Spacer(Modifier.height(8.dp))
-
-            val meal = remember { mutableStateOf("Breakfast") }
-            val range = remember { mutableStateOf("08:00 – 09:00") }
-            val items = remember { mutableStateOf(listOf("Pancakes", "Juice")) }
-            var countdown by remember { mutableStateOf("00:00:00") }
-
-            LaunchedEffect(Unit) {
-                while (true) {
-                    val now = System.currentTimeMillis()
-                    val target = now + 3600000 // +1h
-                    val diff = target - now
-                    val h = diff / 3600000
-                    val m = diff % 3600000 / 60000
-                    val s = diff % 60000 / 1000
-                    countdown = String.format("%02d:%02d:%02d", h, m, s)
-                    kotlinx.coroutines.delay(1000)
+        SectionBox(icon = "\uD83C\uDF74", title = "Today's Menu") {
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                items(meals) { (label, menu) ->
+                    MenuTile(label, menu)
                 }
             }
-
-            Text("${meal.value} · ${range.value}")
-            Text("Starts in $countdown")
-            Text(items.value.joinToString(), modifier = Modifier.padding(top = 8.dp))
-
-            Spacer(modifier = Modifier.weight(1f))
-            Button(
-                onClick = onDismiss,
-                modifier = Modifier.align(Alignment.End)
-            ) { Text("Close") }
         }
+
+        Spacer(Modifier.height(16.dp))
+
+        SectionBox(icon = "\uD83D\uDCDD", title = "Tasks & Reminders") {
+            tasks.forEach { (title, detail) ->
+                Text(title, fontWeight = FontWeight.SemiBold, fontSize = 14.sp, color = Color(0xFF212121))
+                Text(detail, fontSize = 12.sp, color = Color(0xFF757575), modifier = Modifier.padding(bottom = 8.dp))
+            }
+        }
+        Spacer(Modifier.height(16.dp))
     }
 }
 
 @Composable
-private fun BottomPanel(onDismiss: () -> Unit) {
-    Surface(
+fun GreetingBar(firstName: String) {
+    Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(300.dp),
-        shadowElevation = 8.dp,
-        color = Color(0xFFF0F2F5)
+            .background(Color.White)
+            .padding(horizontal = 16.dp)
+            .padding(bottom = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp)
-        ) {
+        Column(modifier = Modifier.weight(1f)) {
             Text(
-                "Reminders / To‑Do",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold
+                text = "Hello, $firstName",
+                fontSize = 24.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = Color(0xFF212121)
             )
-            val reminders = listOf(
-                "Finish ECE1001 Lab report",
-                "Review MAT1002 notes",
-                "PHY1003 problem set",
-                "CHE1004 lab prep",
-                "CSE1005 assignment"
-            )
-            reminders.forEach {
-                Text("• $it", modifier = Modifier.padding(vertical = 4.dp))
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
             Text(
-                "Utilities",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold
+                text = "Saturday, June 7, 2025",
+                fontSize = 14.sp,
+                color = Color(0xFF757575),
+                modifier = Modifier.padding(top = 2.dp)
             )
-            val utilities = listOf(
-                "Calculator",
-                "Attendance Tracker",
-                "Grade Predictor",
-                "Campus Map",
-                "Help Desk"
-            )
-            utilities.forEach {
-                Text(it, modifier = Modifier.padding(vertical = 2.dp))
+            Row(modifier = Modifier.padding(top = 4.dp)) {
+                listOf("\uD83C\uDFA8", "\u2600\uFE0F", "\uD83C\uDF1C", "\uD83C\uDFA8", "\u2600\uFE0F").forEach { e ->
+                    Text(text = e, fontSize = 20.sp, modifier = Modifier.padding(end = 4.dp))
+                }
             }
-
-            Spacer(modifier = Modifier.weight(1f))
-            Button(
-                onClick = onDismiss,
-                modifier = Modifier.align(Alignment.End)
-            ) { Text("Close") }
         }
+        Icon(
+            imageVector = Icons.Default.AccountCircle,
+            contentDescription = null,
+            tint = Color(0xFF757575),
+            modifier = Modifier
+                .size(56.dp)
+                .clip(shape = RoundedCornerShape(28.dp))
+                .clickable { }
+                .padding(4.dp)
+        )
     }
 }
 
+@Composable
+fun SectionBox(
+    icon: String,
+    title: String,
+    onViewAll: (() -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(homeSectionBg)
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+            Text(icon, fontSize = 20.sp)
+            Text(title, fontSize = 18.sp, fontWeight = FontWeight.Bold, modifier = Modifier.padding(start = 8.dp))
+            Spacer(Modifier.weight(1f))
+            if (onViewAll != null) {
+                Text(
+                    text = "View All",
+                    fontSize = 14.sp,
+                    color = accentBlue,
+                    modifier = Modifier.clickable { onViewAll() }
+                )
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        content()
+    }
+}
+
+@Composable
+fun MenuTile(title: String, subtitle: String) {
+    Card(
+        modifier = Modifier.size(width = 150.dp, height = 100.dp),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(1.dp)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.Fastfood,
+                contentDescription = null,
+                tint = accentOrange,
+                modifier = Modifier.size(32.dp)
+            )
+            Text(title, fontWeight = FontWeight.Bold, fontSize = 14.sp, modifier = Modifier.padding(top = 4.dp))
+            Text(subtitle, fontSize = 12.sp, color = Color(0xFF757575), modifier = Modifier.padding(top = 2.dp))
+        }
+    }
+}

--- a/app/src/main/java/com/example/basic/TimetableItem.kt
+++ b/app/src/main/java/com/example/basic/TimetableItem.kt
@@ -1,0 +1,56 @@
+package com.example.basic
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.basic.ui.theme.accentBlue
+
+data class TimetableEntry(
+    val course: String,
+    val lecturer: String,
+    val room: String,
+    val duration: String,
+    val time: String
+)
+
+@Composable
+fun TimetableItem(entry: TimetableEntry, modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(min = 72.dp),
+        shape = RoundedCornerShape(14.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(2.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 12.dp, horizontal = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(entry.course, fontSize = 16.sp, fontWeight = FontWeight.Medium, color = Color(0xFF212121))
+                Text(entry.lecturer, fontSize = 14.sp, color = Color(0xFF757575), modifier = Modifier.padding(top = 2.dp))
+                Text(entry.room, fontSize = 12.sp, color = Color(0xFF9E9E9E), modifier = Modifier.padding(top = 4.dp))
+            }
+            Column(horizontalAlignment = Alignment.End) {
+                Text(entry.duration, fontSize = 14.sp, color = accentBlue)
+                Text(entry.time, fontSize = 12.sp, color = Color(0xFF757575), modifier = Modifier.padding(top = 2.dp))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/basic/WeatherCard.kt
+++ b/app/src/main/java/com/example/basic/WeatherCard.kt
@@ -1,0 +1,90 @@
+package com.example.basic
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Cloud
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun WeatherCard(modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(180.dp),
+        shape = RoundedCornerShape(28.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+        elevation = CardDefaults.cardElevation(0.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .background(
+                    Brush.linearGradient(
+                        listOf(Color(0xFFFF9E4F), Color(0xFFB43DE2))
+                    )
+                )
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Top
+            ) {
+                androidx.compose.material3.Icon(
+                    imageVector = Icons.Outlined.Cloud,
+                    contentDescription = null,
+                    tint = Color.White.copy(alpha = 0.3f),
+                    modifier = Modifier.size(52.dp)
+                )
+                Column(horizontalAlignment = Alignment.End) {
+                    Text(
+                        text = "25°",
+                        color = Color.White,
+                        fontSize = 52.sp,
+                        fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold
+                    )
+                    Text(
+                        text = "Feels like 27°",
+                        color = Color.White.copy(alpha = 0.7f),
+                        fontSize = 12.sp,
+                        modifier = Modifier.padding(top = 2.dp)
+                    )
+                }
+            }
+            Row(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(horizontal = 24.dp),
+                horizontalArrangement = Arrangement.SpaceAround
+            ) {
+                WeatherInfo("60%", "Humidity")
+                WeatherInfo("10 km/h", "Wind")
+                WeatherInfo("28°", "Max")
+            }
+        }
+    }
+}
+
+@Composable
+private fun WeatherInfo(value: String, label: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = value,
+            color = Color.White,
+            fontSize = 20.sp,
+            fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
+        )
+        Text(text = label, color = Color.White, fontSize = 12.sp)
+    }
+}

--- a/app/src/main/java/com/example/basic/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/basic/ui/theme/Theme.kt
@@ -1,5 +1,8 @@
 package com.example.basic.ui.theme
 
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
+
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
@@ -8,3 +11,8 @@ import androidx.compose.runtime.Composable
 fun VitStudentAppTheme(content: @Composable () -> Unit) {
     MaterialTheme(colorScheme = lightColorScheme(), content = content)
 }
+
+val homeSectionBg = Color(0xFFEEF1F8)
+val accentBlue = Color(0xFF2979FF)
+val accentOrange = Color(0xFFFF6D00)
+val shadowSmall = 2.dp


### PR DESCRIPTION
## Summary
- add color constants for Home sections
- overhaul HomeScreen with GreetingBar, WeatherCard, SectionBox, Timetable list, menu grid, and tasks
- add new composables `WeatherCard` and `TimetableItem`

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685e92d41dfc832fa470c70d90202d9f