### PR TITLE
Fix navigation bar color

### DIFF
--- a/app/src/main/java/com/example/basic/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/basic/navigation/AppNavHost.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -107,7 +108,10 @@ fun AppNavHost() {
         bottomBar = {
             val navBackStackEntry by navController.currentBackStackEntryAsState()
             val currentRoute = navBackStackEntry?.destination?.route
-            NavigationBar {
+            NavigationBar(
+                containerColor = Color.White,
+                tonalElevation = 0.dp
+            ) {
                 items.forEach { screen ->
                     val selected = currentRoute == screen.route
                     NavigationBarItem(

--- a/vit-student-app/android/app/src/main/res/values/colors.xml
+++ b/vit-student-app/android/app/src/main/res/values/colors.xml
@@ -3,5 +3,5 @@
   <color name="iconBackground">#ffffff</color>
   <color name="colorPrimary">#023c69</color>
   <color name="colorPrimaryDark">#ffffff</color>
-  <color name="navigationBarColor">#121212</color>
+  <color name="navigationBarColor">#ffffff</color>
 </resources>

--- a/vit-student-app/app.json
+++ b/vit-student-app/app.json
@@ -16,8 +16,8 @@
     // ↓ Update this section:
     "androidNavigationBar": {
       "visible": true,
-      "backgroundColor": "#121212",    // dark shade behind Home/Recents/Back
-      "barStyle": "light-content"      // makes the system icons white
+      "backgroundColor": "#ffffff",
+      "barStyle": "dark-content"
     },
     "plugins": ["expo-media-library", "expo-camera"],
 


### PR DESCRIPTION
## Summary
- update Compose bottom bar to white
- switch Android navigation bar color to white in colors.xml
- match Expo config to white navigation bar

## Testing
- `./gradlew assemble` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685e955a6380832f88cbaaf1e29122a7