### PR TITLE
Update week backgrounds in monthly menu

### DIFF
--- a/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
@@ -37,6 +37,20 @@ data class DayData(val date: String, val meals: List<Meal>)
 
 data class WeekSection(val title: String, val color: Color, val dayColor: Color, val days: List<DayData>)
 
+private val WEEK_COLORS = listOf(
+    Color(0xFFF0E4D7),
+    Color(0xFFE7F0D7),
+    Color(0xFFD7E8F0),
+    Color(0xFFF0D7E8)
+)
+
+private val DAY_COLORS = listOf(
+    Color(0xFFE5D7CB),
+    Color(0xFFDCE5CB),
+    Color(0xFFCBDCE5),
+    Color(0xFFE5CBDC)
+)
+
 private fun parseMonthlyMenu(json: String): MonthlyMenu {
     val obj = JSONObject(json)
     val keys = obj.keys()
@@ -74,11 +88,12 @@ private fun toWeeks(menu: MonthlyMenu): List<WeekSection> {
     var i = 0
     while (i < dates.size) {
         val slice = dates.subList(i, kotlin.math.min(i + 7, dates.size))
+        val index = weeks.size
         weeks.add(
             WeekSection(
-                title = "Week ${weeks.size + 1}",
-                color = Color.White,
-                dayColor = Color.White,
+                title = "Week ${index + 1}",
+                color = WEEK_COLORS[index % WEEK_COLORS.size],
+                dayColor = DAY_COLORS[index % DAY_COLORS.size],
                 days = slice.map { DayData(it, menu[it]!!) }
             )
         )
@@ -120,6 +135,7 @@ fun MonthlyMenuScreen(onBack: () -> Unit) {
     val weeks = remember(menu) { toWeeks(menu!!) }
     val listState = rememberLazyListState()
 
+
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
@@ -150,16 +166,17 @@ fun MonthlyMenuScreen(onBack: () -> Unit) {
             state = listState,
             modifier = Modifier
                 .fillMaxSize()
-                .background(Color(0xFFFFEDEE))
+                .background(Color.White)
                 .padding(padding),
             contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
         ) {
             weeks.forEach { week ->
-                stickyHeader { WeekHeader(week.title) }
+                stickyHeader { WeekHeader(week.title, week.dayColor) }
                 items(week.days) { day ->
                     DayCard(
                         day = day,
                         liked = wishlist.contains(day.date),
+                        background = week.dayColor,
                         onLike = {
                             wishlist = if (wishlist.contains(day.date)) wishlist - day.date else wishlist + day.date
                         },
@@ -189,11 +206,11 @@ fun MonthlyMenuScreen(onBack: () -> Unit) {
 }
 
 @Composable
-private fun WeekHeader(title: String) {
+private fun WeekHeader(title: String, color: Color) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .background(Color(0xFFFFEDEE))
+            .background(color)
             .padding(vertical = 8.dp)
             .zIndex(1f)
     ) {
@@ -213,12 +230,13 @@ private fun WeekHeader(title: String) {
 private fun DayCard(
     day: DayData,
     liked: Boolean,
+    background: Color,
     onLike: () -> Unit,
     onAdd: () -> Unit
 ) {
     Card(
         shape = RoundedCornerShape(12.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.White),
+        colors = CardDefaults.cardColors(containerColor = background),
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 8.dp)


### PR DESCRIPTION
## Summary
- remove scroll-based page background color logic
- keep the main page white while weeks still get their colors

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_685e95331bd4832f96578f45216b7138