### PR TITLE
Update details UI

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceDetailsScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceDetailsScreen.kt
@@ -196,7 +196,7 @@ private fun DaySelector(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .background(Color(0xFFF7F7F7))
+            .background(Color(0xFFE0E0E0))
             .height(52.dp)
             .padding(start = 16.dp, end = 16.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -217,16 +217,19 @@ private fun DaySelector(
                 val isSelected = index == selected
                 val textColor = if (isSelected) Color.White else Color.LightGray
                 val bgColor = if (isSelected) Color(0xFF1E88E5) else Color.Transparent
-                val shape = RoundedCornerShape(12.dp)
+                val shape = RoundedCornerShape(topStart = 0.dp, topEnd = 0.dp, bottomStart = 12.dp, bottomEnd = 12.dp)
+                val highlightOverlap = if (isSelected) 12.dp else 0.dp
                 Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier
-                    .clip(shape)
-                    .clickable { onSelect(index) }
-                    .background(bgColor)
-                    .padding(horizontal = 12.dp, vertical = 4.dp)
-                    .shadow(if (isSelected) 4.dp else 0.dp, shape)
-            ) {
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .padding(bottom = highlightOverlap)
+                        .clip(shape)
+                        .background(bgColor)
+                        .shadow(if (isSelected) 8.dp else 0.dp, shape)
+                        .clickable { onSelect(index) }
+                        .padding(horizontal = 12.dp, vertical = 4.dp)
+                        .align(Alignment.Top)
+                ) {
                 Text(
                     day.date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
                     color = textColor,
@@ -344,7 +347,8 @@ private fun EventCard(event: ClassEvent) {
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 4.dp)
+            .padding(vertical = 8.dp)
+            .height(80.dp)
     ) {
         Row(
             modifier = Modifier


### PR DESCRIPTION
## Summary
- tweak day selector highlight behavior
- enlarge event cards on the details screen
- darker date bar and bigger blue highlight with shadows
- ensure highlight spans to the top of the bar

## Testing
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685e97e6982c832f967909d8cc4d65f4