### PR TITLE
Update week headers

### DIFF
--- a/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
@@ -2,6 +2,7 @@ package com.example.basic
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.lazy.LazyColumn
@@ -36,6 +37,20 @@ typealias MonthlyMenu = Map<String, List<Meal>>
 data class DayData(val date: String, val meals: List<Meal>)
 
 data class WeekSection(val title: String, val color: Color, val dayColor: Color, val days: List<DayData>)
+
+private val WEEK_COLORS = listOf(
+    Color(0xFFF0E4D7),
+    Color(0xFFE7F0D7),
+    Color(0xFFD7E8F0),
+    Color(0xFFF0D7E8)
+)
+
+private val DAY_COLORS = listOf(
+    Color(0xFFE5D7CB),
+    Color(0xFFDCE5CB),
+    Color(0xFFCBDCE5),
+    Color(0xFFE5CBDC)
+)
 
 private fun parseMonthlyMenu(json: String): MonthlyMenu {
     val obj = JSONObject(json)
@@ -74,11 +89,12 @@ private fun toWeeks(menu: MonthlyMenu): List<WeekSection> {
     var i = 0
     while (i < dates.size) {
         val slice = dates.subList(i, kotlin.math.min(i + 7, dates.size))
+        val index = weeks.size
         weeks.add(
             WeekSection(
-                title = "Week ${weeks.size + 1}",
-                color = Color.White,
-                dayColor = Color.White,
+                title = "Week ${index + 1}",
+                color = WEEK_COLORS[index % WEEK_COLORS.size],
+                dayColor = DAY_COLORS[index % DAY_COLORS.size],
                 days = slice.map { DayData(it, menu[it]!!) }
             )
         )
@@ -120,6 +136,7 @@ fun MonthlyMenuScreen(onBack: () -> Unit) {
     val weeks = remember(menu) { toWeeks(menu!!) }
     val listState = rememberLazyListState()
 
+
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
@@ -150,16 +167,22 @@ fun MonthlyMenuScreen(onBack: () -> Unit) {
             state = listState,
             modifier = Modifier
                 .fillMaxSize()
-                .background(Color(0xFFFFEDEE))
+                .background(Color.White)
                 .padding(padding),
             contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
         ) {
             weeks.forEach { week ->
-                stickyHeader { WeekHeader(week.title) }
+                stickyHeader {
+                    WeekHeader(
+                        title = week.title,
+                        color = week.dayColor
+                    )
+                }
                 items(week.days) { day ->
                     DayCard(
                         day = day,
                         liked = wishlist.contains(day.date),
+                        background = week.dayColor,
                         onLike = {
                             wishlist = if (wishlist.contains(day.date)) wishlist - day.date else wishlist + day.date
                         },
@@ -189,18 +212,22 @@ fun MonthlyMenuScreen(onBack: () -> Unit) {
 }
 
 @Composable
-private fun WeekHeader(title: String) {
+private fun WeekHeader(
+    title: String,
+    color: Color
+) {
+    val shape = RoundedCornerShape(50.dp)
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .background(Color(0xFFFFEDEE))
             .padding(vertical = 8.dp)
             .zIndex(1f)
     ) {
         Box(
             modifier = Modifier
                 .align(Alignment.Center)
-                .clip(RoundedCornerShape(50))
+                .clip(shape)
+                .border(2.dp, color, shape)
                 .background(Color.White)
                 .padding(horizontal = 24.dp, vertical = 8.dp)
         ) {
@@ -213,12 +240,13 @@ private fun WeekHeader(title: String) {
 private fun DayCard(
     day: DayData,
     liked: Boolean,
+    background: Color,
     onLike: () -> Unit,
     onAdd: () -> Unit
 ) {
     Card(
         shape = RoundedCornerShape(12.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.White),
+        colors = CardDefaults.cardColors(containerColor = background),
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 8.dp)

--- a/vit-student-app/src/screens/MonthlyMenuScreen.tsx
+++ b/vit-student-app/src/screens/MonthlyMenuScreen.tsx
@@ -206,10 +206,8 @@ export default function MonthlyMenuScreen() {
           renderDay(item, index, section as WeekSection)
         }
         renderSectionHeader={({ section }) => (
-          <View
-            style={[styles.weekHeaderContainer, { backgroundColor: section.dayColor }]}
-          >
-            <View style={styles.weekLabel}>
+          <View style={styles.weekHeaderContainer}>
+            <View style={[styles.weekLabel, { backgroundColor: section.dayColor }]}>
               <Text style={styles.sectionHeader}>{section.title}</Text>
             </View>
           </View>
@@ -233,18 +231,13 @@ const styles = StyleSheet.create({
     marginHorizontal: 4,
     marginBottom: 4,
     padding: 8,
-    borderTopLeftRadius: 12,
-    borderTopRightRadius: 12,
-    borderBottomLeftRadius: 12,
-    borderBottomRightRadius: 12,
-    overflow: 'hidden',
     alignItems: 'center',
   },
   weekLabel: {
     backgroundColor: '#000',
     paddingHorizontal: 12,
     paddingVertical: 4,
-    borderRadius: 20,
+    borderRadius: 50,
   },
   sectionHeader: {
     fontWeight: '600',


### PR DESCRIPTION
## Summary
- stop drawing colored bar behind weekly headers
- keep week header chips rounded in React styles

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to access jarfile)*
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e95331bd4832f96578f45216b7138