### PR TITLE
Fix home screen scrolling

### DIFF
--- a/app/src/main/java/com/example/basic/CardCarousel.kt
+++ b/app/src/main/java/com/example/basic/CardCarousel.kt
@@ -49,21 +49,25 @@ fun CardCarousel(
         onIndexChange?.invoke(pagerState.currentPage)
     }
 
+    val dragModifier = if (pagerState.currentPage > 0) {
+        Modifier.pointerInput(pagerState.currentPage) {
+            detectDragGestures(
+                onDrag = { _, drag ->
+                    dragAmount += drag.y
+                },
+                onDragEnd = {
+                    if (dragAmount > 40f) onSwipeDown() else if (dragAmount < -40f) onSwipeUp()
+                    dragAmount = 0f
+                }
+            )
+        }
+    } else Modifier
+
     Box(
         modifier = modifier
             .fillMaxSize()
             .graphicsLayer { clip = false }
-            .pointerInput(Unit) {
-                detectDragGestures(
-                    onDrag = { _, drag ->
-                        dragAmount += drag.y
-                    },
-                    onDragEnd = {
-                        if (dragAmount > 40f) onSwipeDown() else if (dragAmount < -40f) onSwipeUp()
-                        dragAmount = 0f
-                    }
-                )
-            }
+            .then(dragModifier)
     ) {
         HorizontalPager(
             state = pagerState,

--- a/app/src/main/java/com/example/basic/SummaryCard.kt
+++ b/app/src/main/java/com/example/basic/SummaryCard.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Fastfood
@@ -37,7 +39,12 @@ import androidx.compose.ui.unit.sp
 
 @Composable
 fun SummaryCard() {
-    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
         WeatherCard()
         Spacer(Modifier.height(16.dp))
         TimetableSection()


### PR DESCRIPTION
## Summary
- disable vertical swipe panels on summary page
- add vertical scrolling to the summary card

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eada5d278832f83612d034d75d05a