### PR TITLE
Fix home page header visibility and number row

### DIFF
--- a/app/src/main/java/com/example/basic/CardCarousel.kt
+++ b/app/src/main/java/com/example/basic/CardCarousel.kt
@@ -42,8 +42,9 @@ fun CardCarousel(
     val config = LocalConfiguration.current
     val screenHeight = config.screenHeightDp.dp
     val cardHeight = screenHeight * 0.7f
-    // Position the number row closer to the cards
-    val numberTop = (screenHeight - cardHeight) / 3f + cardHeight - 10.dp
+    // Position the number row closer to the cards and above the navigation bar
+    val bottomBarHeight = 80.dp
+    val numberTop = (screenHeight - cardHeight) / 3f + cardHeight - bottomBarHeight - 10.dp
 
     LaunchedEffect(pagerState.currentPage) {
         onIndexChange?.invoke(pagerState.currentPage)

--- a/app/src/main/java/com/example/basic/HomeScreen.kt
+++ b/app/src/main/java/com/example/basic/HomeScreen.kt
@@ -34,6 +34,7 @@ fun HomeScreen() {
     )
     val cards = listOf(ClassInfo("overview", "", "")) + baseCards
     var panel by remember { mutableStateOf(PanelState.None) }
+    var activeIndex by remember { mutableStateOf(0) }
 
     val config = LocalConfiguration.current
     val headerHeight = config.screenHeightDp.dp * 0.1f
@@ -43,11 +44,13 @@ fun HomeScreen() {
             .fillMaxSize()
             .background(Color(0xFFF0F0F0))
     ) {
-        HomeHeader(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(headerHeight)
-        )
+        AnimatedVisibility(visible = activeIndex == 0) {
+            HomeHeader(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(headerHeight)
+            )
+        }
 
         Box(modifier = Modifier.weight(1f)) {
 
@@ -61,6 +64,7 @@ fun HomeScreen() {
                     if (panel == PanelState.None) panel = PanelState.Bottom
                     else if (panel == PanelState.Top) panel = PanelState.None
                 },
+                onIndexChange = { activeIndex = it },
                 locationName = "Amaravati"
             )
  


### PR DESCRIPTION
## Summary
- hide the greeting header when swiping away from the home page
- adjust the number row in the carousel so it stays above the bottom bar

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_685eaecddb1c832faf651f78c8b57eaf