### PR TITLE
Center month text and bold dates

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceDetailsScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceDetailsScreen.kt
@@ -218,8 +218,8 @@ private fun DaySelector(
                 .fillMaxWidth()
                 .height(52.dp + extraSpace)
                 .padding(start = 16.dp, end = 16.dp)
-                .align(Alignment.TopStart),
-            verticalAlignment = Alignment.Top
+                .align(Alignment.CenterStart),
+            verticalAlignment = Alignment.CenterVertically
         ) {
         Text(
             month,
@@ -262,7 +262,8 @@ private fun DaySelector(
                 Text(
                     day.date.dayOfMonth.toString(),
                     color = textColor,
-                    fontSize = 12.sp
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold
                 )
             }
         }


### PR DESCRIPTION
## Summary
- center the month label vertically within the day bar
- keep day numbers bold

## Testing
- `./gradlew test --quiet` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685eb5641a38832fb6f4b5d2e0f53aa1