### PR TITLE
Center month text and bold dates

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceDetailsScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceDetailsScreen.kt
@@ -216,10 +216,10 @@ private fun DaySelector(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(52.dp + extraSpace)
+                .height(52.dp)
                 .padding(start = 16.dp, end = 16.dp)
                 .align(Alignment.TopStart),
-            verticalAlignment = Alignment.Top
+            verticalAlignment = Alignment.CenterVertically
         ) {
         Text(
             month,
@@ -262,7 +262,8 @@ private fun DaySelector(
                 Text(
                     day.date.dayOfMonth.toString(),
                     color = textColor,
-                    fontSize = 12.sp
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold
                 )
             }
         }


### PR DESCRIPTION
## Summary
- center the month label vertically within the day bar
- keep day numbers bold

## Testing
- `./gradlew test --quiet` *(fails: Unable to access jarfile gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685eb5641a38832fb6f4b5d2e0f53aa1