### PR TITLE
Center day label in attendance details

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceDetailsScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceDetailsScreen.kt
@@ -243,12 +243,13 @@ private fun DaySelector(
                 val itemHeight = 52.dp + highlightOverlap
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
                     modifier = Modifier
                         .height(itemHeight)
                         .shadow(if (isSelected) 12.dp else 0.dp, shape, clip = false)
                         .clip(shape)
                         .background(bgColor, shape)
- 
+
                         .clickable { onSelect(index) }
                         .padding(horizontal = 12.dp, vertical = 4.dp)
                         .align(Alignment.CenterVertically)


### PR DESCRIPTION
## Summary
- center day items vertically within the day selector bar in AttendanceDetailsScreen

## Testing
- `./gradlew test` *(fails: Unable to access gradle wrapper jar)*
- `npx tsc --noEmit` *(fails: multiple missing modules and JSX errors)*

------
https://chatgpt.com/codex/tasks/task_e_685eb91eadf8832fa0e1045a78b49ce2