### PR TITLE
Fix layout shift for header

### DIFF
--- a/app/src/main/java/com/example/basic/HomeScreen.kt
+++ b/app/src/main/java/com/example/basic/HomeScreen.kt
@@ -44,12 +44,16 @@ fun HomeScreen() {
             .fillMaxSize()
             .background(Color(0xFFF0F0F0))
     ) {
-        AnimatedVisibility(visible = activeIndex == 0) {
-            HomeHeader(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(headerHeight)
-            )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(headerHeight)
+        ) {
+            androidx.compose.animation.AnimatedVisibility(visible = activeIndex == 0) {
+                HomeHeader(
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
         }
 
         Box(modifier = Modifier.weight(1f)) {


### PR DESCRIPTION
## Summary
- keep a fixed `HomeHeader` container height
- explicitly qualify `AnimatedVisibility` to avoid ColumnScope reference

## Testing
- `./gradlew test --no-daemon` *(fails: gradle-wrapper.jar missing)*

------
https://chatgpt.com/codex/tasks/task_e_685eb9c4e290832faf5910239c6deabe