### PR TITLE
Fix weather widget layout

### DIFF
--- a/app/src/main/java/com/example/basic/SummaryCard.kt
+++ b/app/src/main/java/com/example/basic/SummaryCard.kt
@@ -88,44 +88,48 @@ private fun WeatherCard() {
                 .fillMaxSize()
         ) {
             Row(
-                modifier = Modifier.fillMaxSize(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .offset(y = 8.dp)
             ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    AsyncImage(
-                        model = coil.request.ImageRequest.Builder(LocalContext.current)
-                            .data("https://placekitten.com/128/128")
-                            .crossfade(true)
-                            .size(coil.size.Size.ORIGINAL)
-                            .build(),
-                        contentDescription = null,
-                        modifier = Modifier.size(72.dp),
-                        placeholder = painterResource(android.R.drawable.ic_menu_report_image),
-                        contentScale = ContentScale.Fit
-                    )
-                    Spacer(Modifier.width(12.dp))
-                    Text(
-                        "Cloudy",
-                        color = Color.White,
-                        fontSize = 32.sp,
-                        fontWeight = FontWeight.Bold
-                    )
-                }
-                Column(horizontalAlignment = Alignment.End) {
-                    Text(
-                        "25°",
-                        color = Color.White,
-                        fontSize = 52.sp,
-                        fontWeight = FontWeight.Bold
-                    )
-                    Text(
-                        "Feels like 27°",
-                        color = Color.White,
-                        fontSize = 12.sp,
-                        modifier = Modifier.offset(x = (-10).dp, y = (-10).dp)
-                    )
-                }
+                AsyncImage(
+                    model = coil.request.ImageRequest.Builder(LocalContext.current)
+                        .data("https://placekitten.com/128/128")
+                        .crossfade(true)
+                        .size(coil.size.Size.ORIGINAL)
+                        .build(),
+                    contentDescription = null,
+                    modifier = Modifier.size(72.dp),
+                    placeholder = painterResource(android.R.drawable.ic_menu_report_image),
+                    contentScale = ContentScale.Fit
+                )
+                Spacer(Modifier.width(12.dp))
+                Text(
+                    "Cloudy",
+                    color = Color.White,
+                    fontSize = 32.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+            Column(
+                horizontalAlignment = Alignment.End,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .offset(y = 8.dp)
+            ) {
+                Text(
+                    "25°",
+                    color = Color.White,
+                    fontSize = 52.sp,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    "Feels like 27°",
+                    color = Color.White,
+                    fontSize = 12.sp,
+                    modifier = Modifier.offset(x = (-10).dp, y = (-10).dp)
+                )
             }
             Row(
                 modifier = Modifier


### PR DESCRIPTION
## Summary
- allow free placement of weather info in `WeatherCard`
- move current conditions downward slightly

## Testing
- `gradle test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685eb95e4bdc832f85f83f9d7d8db3ce