### PR TITLE
Add cloud icon in weather card

### DIFF
--- a/app/src/main/java/com/example/basic/SummaryCard.kt
+++ b/app/src/main/java/com/example/basic/SummaryCard.kt
@@ -19,10 +19,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Fastfood
-import coil.compose.AsyncImage
-import coil.compose.AsyncImagePainter
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.layout.ContentScale
+import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -31,7 +28,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -107,16 +103,11 @@ private fun WeatherCard() {
                     .align(Alignment.TopStart)
                     .offset(y = 8.dp)
             ) {
-                AsyncImage(
-                    model = coil.request.ImageRequest.Builder(LocalContext.current)
-                        .data("https://placekitten.com/128/128")
-                        .crossfade(true)
-                        .size(coil.size.Size.ORIGINAL)
-                        .build(),
-                    contentDescription = null,
-                    modifier = Modifier.size(72.dp),
-                    placeholder = painterResource(android.R.drawable.ic_menu_report_image),
-                    contentScale = ContentScale.Fit
+                Icon(
+                    imageVector = Icons.Filled.Cloud,
+                    contentDescription = "Cloudy",
+                    tint = Color.White,
+                    modifier = Modifier.size(72.dp)
                 )
                 Spacer(Modifier.width(12.dp))
                 Text(


### PR DESCRIPTION
## Summary
- replace placeholder image with a large cloud icon in `WeatherCard`

## Testing
- `./gradlew assembleDebug` *(fails: unable to access wrapper jar)*

------
https://chatgpt.com/codex/tasks/task_e_685ec0e83ee4832f879e3f4ac1344224