### PR TITLE
Fix menu cards stretch

### DIFF
--- a/app/src/main/java/com/example/basic/SummaryCard.kt
+++ b/app/src/main/java/com/example/basic/SummaryCard.kt
@@ -224,23 +224,47 @@ private fun MenuSection() {
     )
     Column {
         meals.chunked(2).forEach { rowItems ->
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally)
+            ) {
                 rowItems.forEach { (label, menu) ->
                     Card(
                         modifier = Modifier
-                            .weight(1f)
+                            .widthIn(max = 160.dp)
+                            .weight(1f, fill = false)
                             .padding(4.dp),
                         colors = CardDefaults.cardColors(containerColor = Color.White),
                         elevation = CardDefaults.cardElevation(1.dp)
                     ) {
-                        Column(modifier = Modifier.padding(12.dp), horizontalAlignment = Alignment.CenterHorizontally) {
-                            Icon(Icons.Default.Fastfood, contentDescription = null, tint = Color(0xFFFF6A00))
-                            Text(label, fontWeight = FontWeight.SemiBold, modifier = Modifier.padding(top = 4.dp))
-                            Text(menu, fontSize = 12.sp, modifier = Modifier.padding(top = 4.dp))
+                        Column(
+                            modifier = Modifier.padding(12.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Icon(
+                                Icons.Default.Fastfood,
+                                contentDescription = null,
+                                tint = Color(0xFFFF6A00)
+                            )
+                            Text(
+                                label,
+                                fontWeight = FontWeight.SemiBold,
+                                modifier = Modifier.padding(top = 4.dp)
+                            )
+                            Text(
+                                menu,
+                                fontSize = 12.sp,
+                                modifier = Modifier.padding(top = 4.dp)
+                            )
                         }
                     }
                 }
-                if (rowItems.size == 1) Spacer(Modifier.weight(1f))
+                if (rowItems.size == 1) Spacer(
+                    modifier = Modifier
+                        .widthIn(max = 160.dp)
+                        .weight(1f, fill = false)
+                        .padding(4.dp)
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- stop menu cards from stretching across wide screens
- center the cards and keep them equal size

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685ec1d90b1c832fa972adfaea076f60