### PR TITLE
Update menu box layout

### DIFF
--- a/app/src/main/java/com/example/basic/SummaryCard.kt
+++ b/app/src/main/java/com/example/basic/SummaryCard.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -208,6 +208,9 @@ private fun TimetableSection() {
 @Composable
 private fun MenuSection() {
     SectionHeader("Today's Menu")
+    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+    val cardWidth = screenWidth * 0.37f
+    val spacing = (screenWidth - cardWidth * 2) / 3f
     val meals = listOf(
         "Breakfast" to "Pancakes & Juice",
         "Lunch" to "Chicken Salad",
@@ -217,15 +220,17 @@ private fun MenuSection() {
     Column {
         meals.chunked(2).forEach { rowItems ->
             Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally)
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = spacing),
+                horizontalArrangement = Arrangement.spacedBy(spacing)
             ) {
                 rowItems.forEach { (label, menu) ->
                     Card(
                         modifier = Modifier
-                            .widthIn(max = 160.dp)
-                            .weight(1f, fill = false)
-                            .padding(4.dp),
+                            .width(cardWidth)
+                            .padding(vertical = 8.dp),
+                        border = BorderStroke(1.dp, Color(0xFFE0E0E0)),
                         colors = CardDefaults.cardColors(containerColor = Color.White),
                         elevation = CardDefaults.cardElevation(1.dp)
                     ) {
@@ -253,9 +258,8 @@ private fun MenuSection() {
                 }
                 if (rowItems.size == 1) Spacer(
                     modifier = Modifier
-                        .widthIn(max = 160.dp)
-                        .weight(1f, fill = false)
-                        .padding(4.dp)
+                        .width(cardWidth)
+                        .padding(vertical = 8.dp)
                 )
             }
         }

--- a/vit-student-app/src/components/SummaryCard.tsx
+++ b/vit-student-app/src/components/SummaryCard.tsx
@@ -461,15 +461,15 @@ const styles = StyleSheet.create({
   hoursText:   { fontSize:12, fontWeight:'600', color:'#333' },
   roomText:    { fontSize:10, color:'#999', marginTop:2 },
 
-  menuGrid: { flexDirection:'row', flexWrap:'wrap', justifyContent:'space-between' },
+  menuGrid: { flexDirection:'row', flexWrap:'wrap', justifyContent:'space-between', paddingHorizontal:'8.7%' },
   menuBox:  {
-    // adjust width so two menu items fit side‑by‑side
-    width: '46%',
+    width: '37%',
     backgroundColor:'#fff',
     borderRadius:12,
+    borderWidth:1,
+    borderColor:'#ddd',
     padding:12,
     marginVertical:8,
-    marginHorizontal:4,
     alignItems:'center',
     elevation:1,
     shadowColor:'#000',


### PR DESCRIPTION
## Summary
- tweak `SummaryCard` layout in React Native app
- match styling in Android Compose version
- compute spacing to keep gaps equal

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685ec3d6e1b4832fbcc8095d47427922