### PR TITLE
Scroll to current day in monthly menu

### DIFF
--- a/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
@@ -137,6 +137,21 @@ fun MonthlyMenuScreen(onBack: () -> Unit) {
     val weeks = remember(menu) { toWeeks(menu!!) }
     val listState = rememberLazyListState()
 
+    LaunchedEffect(weeks) {
+        val today = LocalDate.now().format(dateFormatter)
+        var index = 0
+        for (week in weeks) {
+            index += 1 // account for header
+            val dayIdx = week.days.indexOfFirst { it.date == today }
+            if (dayIdx >= 0) {
+                index += dayIdx
+                listState.scrollToItem(index)
+                break
+            }
+            index += week.days.size
+        }
+    }
+
 
     Scaffold(
         topBar = {


### PR DESCRIPTION
## Summary
- scroll to today's menu when opening the Monthly Menu screen

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_685ec9dafc24832fa2aede91b05c4950