### PR TITLE
Fix menu card width

### DIFF
--- a/app/src/main/java/com/example/basic/SummaryCard.kt
+++ b/app/src/main/java/com/example/basic/SummaryCard.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -34,6 +34,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.sp
 
 @Composable
@@ -59,7 +60,7 @@ fun SummaryCard() {
             Spacer(Modifier.height(16.dp))
             TimetableSection()
             Spacer(Modifier.height(16.dp))
-            MenuSection()
+            MenuSection(contentPadding = 16.dp)
             Spacer(Modifier.height(16.dp))
             TasksSection()
             Spacer(Modifier.height(16.dp))
@@ -206,8 +207,13 @@ private fun TimetableSection() {
 }
 
 @Composable
-private fun MenuSection() {
+private fun MenuSection(contentPadding: Dp) {
     SectionHeader("Today's Menu")
+    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+    val cardWidth = screenWidth * 0.37f
+    val cardHeight = 120.dp
+    val spacing = (screenWidth - cardWidth * 2) / 3f
+    val rowPadding = (spacing - contentPadding).coerceAtLeast(0.dp)
     val meals = listOf(
         "Breakfast" to "Pancakes & Juice",
         "Lunch" to "Chicken Salad",
@@ -217,15 +223,18 @@ private fun MenuSection() {
     Column {
         meals.chunked(2).forEach { rowItems ->
             Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally)
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = rowPadding),
+                horizontalArrangement = Arrangement.spacedBy(spacing)
             ) {
                 rowItems.forEach { (label, menu) ->
                     Card(
                         modifier = Modifier
-                            .widthIn(max = 160.dp)
-                            .weight(1f, fill = false)
-                            .padding(4.dp),
+                            .width(cardWidth)
+                            .height(cardHeight)
+                            .padding(vertical = 8.dp),
+                        border = BorderStroke(1.dp, Color(0xFFE0E0E0)),
                         colors = CardDefaults.cardColors(containerColor = Color.White),
                         elevation = CardDefaults.cardElevation(1.dp)
                     ) {
@@ -253,9 +262,9 @@ private fun MenuSection() {
                 }
                 if (rowItems.size == 1) Spacer(
                     modifier = Modifier
-                        .widthIn(max = 160.dp)
-                        .weight(1f, fill = false)
-                        .padding(4.dp)
+                        .width(cardWidth)
+                        .height(cardHeight)
+                        .padding(vertical = 8.dp)
                 )
             }
         }

--- a/vit-student-app/src/components/SummaryCard.tsx
+++ b/vit-student-app/src/components/SummaryCard.tsx
@@ -28,6 +28,13 @@ const GRADIENT_RATIO = 0.16;
 const GRADIENT_HEIGHT = height * GRADIENT_RATIO + STATUS_BAR_HEIGHT;
 const GRADIENT_WIDTH = width * 0.9;
 
+// Menu card sizing
+const CONTENT_PADDING = 24;
+const CARD_WIDTH = width * 0.37;
+const CARD_HEIGHT = 120;
+const MENU_SPACING = (width - CARD_WIDTH * 2) / 3;
+const MENU_GRID_PADDING = Math.max(MENU_SPACING - CONTENT_PADDING, 0);
+
 const AnimatedLinearGradient = Animated.createAnimatedComponent(LinearGradient);
 const AnimatedScrollView     = Animated.createAnimatedComponent(ScrollView);
 
@@ -461,16 +468,23 @@ const styles = StyleSheet.create({
   hoursText:   { fontSize:12, fontWeight:'600', color:'#333' },
   roomText:    { fontSize:10, color:'#999', marginTop:2 },
 
-  menuGrid: { flexDirection:'row', flexWrap:'wrap', justifyContent:'space-between' },
+  menuGrid: {
+    flexDirection:'row',
+    flexWrap:'wrap',
+    justifyContent:'space-between',
+    paddingHorizontal: MENU_GRID_PADDING,
+  },
   menuBox:  {
-    // adjust width so two menu items fit side‑by‑side
-    width: '46%',
+    width: CARD_WIDTH,
+    height: CARD_HEIGHT,
     backgroundColor:'#fff',
     borderRadius:12,
+    borderWidth:1,
+    borderColor:'#ddd',
     padding:12,
     marginVertical:8,
-    marginHorizontal:4,
     alignItems:'center',
+    justifyContent:'center',
     elevation:1,
     shadowColor:'#000',
     shadowOpacity:0.05,


### PR DESCRIPTION
## Summary
- pass column padding to Compose menu layout so spacing accounts for outer padding
- calculate padding in React Native so each menu card uses 37% of the page width

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685ec3d6e1b4832fbcc8095d47427922