### PR TITLE
Improve attendance screen visuals

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceScreen.kt
@@ -1,10 +1,16 @@
 package com.example.basic
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.ui.Alignment
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
@@ -17,18 +23,19 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.example.basic.DoubleRingProgress
 
-private data class Subject(val name: String, val code: String)
+private data class Subject(val name: String, val code: String, val attendance: Float)
 
 @Composable
 fun AttendanceScreen() {
     val subjects = listOf(
-        Subject("Mathematics", "MAT101"),
-        Subject("Physics", "PHY102"),
-        Subject("Chemistry", "CHE103"),
-        Subject("Computer Science", "CSE104"),
-        Subject("English", "ENG105"),
-        Subject("Electronics", "ELE106")
+        Subject("Mathematics", "MAT101", 0.85f),
+        Subject("Physics", "PHY102", 0.75f),
+        Subject("Chemistry", "CHE103", 0.60f),
+        Subject("Computer Science", "CSE104", 0.95f),
+        Subject("English", "ENG105", 0.80f),
+        Subject("Electronics", "ELE106", 0.50f)
     )
 
     Column(
@@ -41,22 +48,47 @@ fun AttendanceScreen() {
             Card(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(120.dp)
+                    .heightIn(min = 160.dp)
                     .padding(vertical = 8.dp),
                 colors = CardDefaults.cardColors(containerColor = Color.White),
                 elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
             ) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    Text(
-                        text = subject.name,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold
-                    )
-                    Text(
-                        text = subject.code,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = Color.Gray
-                    )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.Top,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Column {
+                        Text(
+                            text = subject.name,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            text = subject.code,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.Gray,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                    Column(
+                        modifier = Modifier.align(Alignment.CenterVertically),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        DoubleRingProgress(
+                            progress = subject.attendance,
+                            modifier = Modifier.size(96.dp)
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = "Btw exams: ${(subject.attendance * 100).toInt()}%",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Color.Gray,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/basic/DoubleRingProgress.kt
+++ b/app/src/main/java/com/example/basic/DoubleRingProgress.kt
@@ -1,0 +1,88 @@
+package com.example.basic
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Alignment
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.font.FontWeight
+
+@Composable
+fun DoubleRingProgress(
+    progress: Float,
+    modifier: Modifier = Modifier,
+    color: Color = Color(0xFF3F51B5),
+    trackColor: Color = color.copy(alpha = 0.3f),
+    thickness: Dp = 8.dp,
+    gap: Dp = 4.dp
+) {
+    BoxWithConstraints(modifier = modifier, contentAlignment = Alignment.Center) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val strokeWidth = thickness.toPx()
+            val stroke = Stroke(width = strokeWidth, cap = StrokeCap.Butt)
+            val gapPx = gap.toPx()
+            val outerRadius = size.minDimension / 2
+            val innerRadius = outerRadius - strokeWidth - gapPx
+
+            // Outer track
+            drawArc(
+                color = trackColor,
+                startAngle = -90f,
+                sweepAngle = 360f,
+                useCenter = false,
+                style = stroke,
+                size = Size(outerRadius * 2, outerRadius * 2),
+                topLeft = Offset(center.x - outerRadius, center.y - outerRadius)
+            )
+
+            // Outer progress
+            drawArc(
+                color = color,
+                startAngle = -90f,
+                sweepAngle = 360f * progress.coerceIn(0f, 1f),
+                useCenter = false,
+                style = stroke,
+                size = Size(outerRadius * 2, outerRadius * 2),
+                topLeft = Offset(center.x - outerRadius, center.y - outerRadius)
+            )
+
+            // Inner track
+            drawArc(
+                color = trackColor,
+                startAngle = -90f,
+                sweepAngle = 360f,
+                useCenter = false,
+                style = stroke,
+                size = Size(innerRadius * 2, innerRadius * 2),
+                topLeft = Offset(center.x - innerRadius, center.y - innerRadius)
+            )
+
+            // Inner progress
+            drawArc(
+                color = color,
+                startAngle = -90f,
+                sweepAngle = 360f * progress.coerceIn(0f, 1f),
+                useCenter = false,
+                style = stroke,
+                size = Size(innerRadius * 2, innerRadius * 2),
+                topLeft = Offset(center.x - innerRadius, center.y - innerRadius)
+            )
+        }
+        Text(
+            text = "${(progress * 100).toInt()}%",
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- allow attendance cards to expand vertically so content isn't cut off
- show larger percentage text inside progress rings using same color as course names
- add DoubleRingProgress composable with straight stroke caps for smooth rendering
- fix missing import for `heightIn`
- put subject info at top-left and bold all texts

## Testing
- `gradle assembleRelease --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd09c8758832f89c42597b1d23514