### PR TITLE
Add dark grey mini graph with scaled y-axis

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.width
 import androidx.compose.ui.Alignment
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -24,6 +26,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.basic.DoubleRingProgress
+import com.example.basic.MiniLineGraph
 
 private data class Subject(val name: String, val code: String, val attendance: Float)
 
@@ -60,17 +63,30 @@ fun AttendanceScreen() {
                     verticalAlignment = Alignment.Top,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Column {
-                        Text(
-                            text = subject.name,
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold
-                        )
-                        Text(
-                            text = subject.code,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = Color.Gray,
-                            fontWeight = FontWeight.Bold
+                    Column(
+                        modifier = Modifier
+                            .fillMaxHeight(),
+                        verticalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Column {
+                            Text(
+                                text = subject.name,
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Text(
+                                text = subject.code,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.Gray,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                        MiniLineGraph(
+                            data = listOf(0.6f, 0.8f, 0.7f, 0.9f, 0.65f),
+                            modifier = Modifier
+                                .padding(top = 8.dp)
+                                .width(80.dp)
+                                .height(32.dp)
                         )
                     }
                     Column(

--- a/app/src/main/java/com/example/basic/MiniLineGraph.kt
+++ b/app/src/main/java/com/example/basic/MiniLineGraph.kt
@@ -1,0 +1,64 @@
+package com.example.basic
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun MiniLineGraph(
+    data: List<Float>,
+    modifier: Modifier = Modifier,
+    lineColor: Color = Color.DarkGray,
+    heightRatio: Float = 0.5f
+) {
+    Canvas(modifier = modifier) {
+        if (data.isEmpty()) return@Canvas
+
+        val maxValue = data.maxOrNull() ?: 0f
+        val minValue = data.minOrNull() ?: 0f
+        val range = (maxValue - minValue).takeIf { it != 0f } ?: 1f
+
+        val stepX = if (data.size > 1) size.width / (data.size - 1) else 0f
+        val path = Path()
+        val fillPath = Path()
+
+        val availableHeight = size.height * heightRatio
+
+        data.forEachIndexed { index, value ->
+            val x = index * stepX
+            val normalized = (value - minValue) / range
+            val y = size.height - normalized * availableHeight
+            if (index == 0) {
+                path.moveTo(x, y)
+                fillPath.moveTo(x, size.height)
+                fillPath.lineTo(x, y)
+            } else {
+                path.lineTo(x, y)
+                fillPath.lineTo(x, y)
+            }
+        }
+        fillPath.lineTo(size.width, size.height)
+        fillPath.close()
+
+        drawPath(
+            path = fillPath,
+            brush = Brush.verticalGradient(
+                colors = listOf(Color.LightGray.copy(alpha = 0.4f), Color.Transparent)
+            ),
+            style = Fill
+        )
+
+        drawPath(
+            path = path,
+            color = lineColor,
+            style = Stroke(width = 2.dp.toPx(), cap = StrokeCap.Round)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- tweak `MiniLineGraph` to default to a dark grey line
- add `heightRatio` parameter and use it to cap the y-axis to half the height
- guard against single-point data

## Testing
- `./gradlew assembleDebug --no-daemon` *(fails: gradle-wrapper.jar missing)*

------
https://chatgpt.com/codex/tasks/task_e_685fe2be06c4832fa4ff970726c412d0