### PR TITLE
Improve attendance card colors

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceScreen.kt
@@ -61,13 +61,12 @@ fun AttendanceScreen() {
                         .fillMaxWidth()
                         .heightIn(min = 160.dp)
                         .padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
+                    verticalAlignment = Alignment.Top,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     Column(
                         modifier = Modifier
-                            .fillMaxHeight()
-                            .align(Alignment.Bottom),
+                            .fillMaxHeight(),
                         verticalArrangement = Arrangement.SpaceBetween
                     ) {
                         Column {
@@ -95,9 +94,16 @@ fun AttendanceScreen() {
                         modifier = Modifier.align(Alignment.CenterVertically),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
+                        val progressColor = when {
+                            subject.attendance >= 0.75f -> Color(0xFF55b45e)
+                            subject.attendance >= 0.70f -> Color(0xFFe5a967)
+                            else -> Color(0xFFe06846)
+                        }
                         DoubleRingProgress(
                             progress = subject.attendance,
-                            modifier = Modifier.size(96.dp)
+                            modifier = Modifier.size(96.dp),
+                            color = progressColor,
+                            trackColor = progressColor.copy(alpha = 0.3f)
                         )
                         Spacer(modifier = Modifier.height(8.dp))
                         Text(


### PR DESCRIPTION
## Summary
- tweak attendance list layout
- show progress color based on attendance percentage

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe8e43cc0832f8ba1fccc0f58f2e8