### PR TITLE
Keep graph bottom and use dual progress

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceScreen.kt
@@ -95,13 +95,22 @@ fun AttendanceScreen() {
                         modifier = Modifier.align(Alignment.CenterVertically),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
+                        val progressColor = when {
+                            subject.attendance >= 0.75f -> Color(0xFF55b45e)
+                            subject.attendance >= 0.70f -> Color(0xFFe5a967)
+                            else -> Color(0xFFe06846)
+                        }
+                        val inner = (subject.attendance - 0.1f).coerceAtLeast(0f)
                         DoubleRingProgress(
-                            progress = subject.attendance,
-                            modifier = Modifier.size(96.dp)
+                            outerProgress = subject.attendance,
+                            innerProgress = inner,
+                            modifier = Modifier.size(96.dp),
+                            color = progressColor,
+                            trackColor = progressColor.copy(alpha = 0.3f)
                         )
                         Spacer(modifier = Modifier.height(8.dp))
                         Text(
-                            text = "Btw exams: ${(subject.attendance * 100).toInt()}%",
+                            text = "Btw exams: ${(inner * 100).toInt()}%",
                             style = MaterialTheme.typography.bodyMedium,
                             color = Color.Gray,
                             fontWeight = FontWeight.Bold

--- a/app/src/main/java/com/example/basic/DoubleRingProgress.kt
+++ b/app/src/main/java/com/example/basic/DoubleRingProgress.kt
@@ -19,7 +19,8 @@ import androidx.compose.ui.text.font.FontWeight
 
 @Composable
 fun DoubleRingProgress(
-    progress: Float,
+    outerProgress: Float,
+    innerProgress: Float,
     modifier: Modifier = Modifier,
     color: Color = Color(0xFF3F51B5),
     trackColor: Color = color.copy(alpha = 0.3f),
@@ -49,7 +50,7 @@ fun DoubleRingProgress(
             drawArc(
                 color = color,
                 startAngle = -90f,
-                sweepAngle = 360f * progress.coerceIn(0f, 1f),
+                sweepAngle = 360f * outerProgress.coerceIn(0f, 1f),
                 useCenter = false,
                 style = stroke,
                 size = Size(outerRadius * 2, outerRadius * 2),
@@ -71,7 +72,7 @@ fun DoubleRingProgress(
             drawArc(
                 color = color,
                 startAngle = -90f,
-                sweepAngle = 360f * progress.coerceIn(0f, 1f),
+                sweepAngle = 360f * innerProgress.coerceIn(0f, 1f),
                 useCenter = false,
                 style = stroke,
                 size = Size(innerRadius * 2, innerRadius * 2),
@@ -79,7 +80,7 @@ fun DoubleRingProgress(
             )
         }
         Text(
-            text = "${(progress * 100).toInt()}%",
+            text = "${(outerProgress * 100).toInt()}%",
             style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colorScheme.onSurface,
             fontWeight = FontWeight.Bold

--- a/app/src/main/java/com/example/basic/MiniLineGraph.kt
+++ b/app/src/main/java/com/example/basic/MiniLineGraph.kt
@@ -50,7 +50,7 @@ fun MiniLineGraph(
         drawPath(
             path = fillPath,
             brush = Brush.verticalGradient(
-                colors = listOf(Color.Gray.copy(alpha = 0.5f), Color.White)
+                colors = listOf(lineColor.copy(alpha = 0.7f), Color.Transparent)
             ),
             style = Fill
         )


### PR DESCRIPTION
## Summary
- restore bottom-left mini graph
- split inner and outer progress values
- color progress rings based on attendance
- increase the mini graph gradient visibility

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe8e43cc0832f8ba1fccc0f58f2e8