### PR TITLE
Fix MoreScreen dividers

### DIFF
--- a/app/src/main/java/com/example/basic/MoreScreen.kt
+++ b/app/src/main/java/com/example/basic/MoreScreen.kt
@@ -2,23 +2,85 @@ package com.example.basic
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Divider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.TextStyle
+import java.time.temporal.TemporalAdjusters
+import java.util.Locale
 
 @Composable
 fun MoreScreen() {
+    val today = LocalDate.now()
+    val monthLabel = remember {
+        today.format(DateTimeFormatter.ofPattern("MMMM yyyy"))
+    }
+    val startOfWeek = remember {
+        today.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY))
+    }
+    val weekDates = remember {
+        (0..6).map { startOfWeek.plusDays(it.toLong()) }
+    }
+    // Use a single shade for the top and bottom dividers
+    val dividerColor = Color.DarkGray
+
     Column(
         modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
-            text = "More screen coming soon.",
-            style = MaterialTheme.typography.bodyLarge
+            text = monthLabel,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(vertical = 16.dp)
+        )
+        Divider(
+            color = dividerColor,
+            thickness = 0.5.dp,
+            modifier = Modifier.padding(vertical = 12.dp)
+        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            weekDates.forEach { date ->
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    val day = date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault())
+                    Text(
+                        text = day,
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = date.dayOfMonth.toString(),
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+        }
+        Divider(
+            color = dividerColor,
+            thickness = 0.5.dp,
+            modifier = Modifier.padding(vertical = 12.dp)
         )
     }
 }


### PR DESCRIPTION
## Summary
- keep divider color consistent across the week row
- evenly space days across the screen and use bold fonts
- add more vertical padding around dividers

## Testing
- `./gradlew assembleDebug` *(fails: unable to access `gradle-wrapper.jar`)*
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ffd668c34832fb77e63688edc4a9f