### PR TITLE
Show full day in calendar

### DIFF
--- a/app/src/main/java/com/example/basic/MoreScreen.kt
+++ b/app/src/main/java/com/example/basic/MoreScreen.kt
@@ -2,6 +2,7 @@ package com.example.basic
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -37,10 +38,34 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import java.time.DayOfWeek
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle
 import java.time.temporal.TemporalAdjusters
 import java.util.Locale
+
+// Simple schedule model for the calendar
+private enum class ClassType { THEORY, LAB, BREAK, LUNCH }
+
+private data class DayClass(
+    val title: String,
+    val start: LocalTime,
+    val end: LocalTime,
+    val type: ClassType
+)
+
+private val SAMPLE_DAY = listOf(
+    DayClass("Math", LocalTime.of(9, 0), LocalTime.of(9, 50), ClassType.THEORY),
+    DayClass("Physics Lab", LocalTime.of(10, 0), LocalTime.of(10, 50), ClassType.LAB),
+    DayClass("Break", LocalTime.of(11, 0), LocalTime.of(12, 0), ClassType.BREAK),
+    DayClass("Lunch", LocalTime.of(12, 0), LocalTime.of(13, 30), ClassType.LUNCH),
+    DayClass("Algorithms", LocalTime.of(13, 30), LocalTime.of(14, 20), ClassType.THEORY),
+    DayClass("Electronics", LocalTime.of(14, 30), LocalTime.of(15, 10), ClassType.LAB),
+    DayClass("Databases", LocalTime.of(15, 20), LocalTime.of(16, 0), ClassType.THEORY)
+)
+
+private val WEEK_CLASSES: Map<DayOfWeek, List<DayClass>> =
+    DayOfWeek.values().associateWith { SAMPLE_DAY }
 
 @Composable
 fun MoreScreen() {
@@ -54,6 +79,7 @@ fun MoreScreen() {
     val weekDates = remember {
         (0..6).map { startOfWeek.plusDays(it.toLong()) }
     }
+    var selectedDay by remember { mutableStateOf(today.dayOfWeek) }
     // Use a single shade for the top and bottom dividers
     val dividerColor = Color.DarkGray
 
@@ -79,8 +105,14 @@ fun MoreScreen() {
             horizontalArrangement = Arrangement.SpaceEvenly
         ) {
             weekDates.forEach { date ->
+                val selected = date.dayOfWeek == selectedDay
                 Column(
-                    horizontalAlignment = Alignment.CenterHorizontally
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(if (selected) Color(0xFFBBDEFB) else Color.Transparent)
+                        .clickable { selectedDay = date.dayOfWeek }
+                        .padding(vertical = 4.dp, horizontal = 6.dp)
                 ) {
                     val day = date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault())
                     Text(
@@ -151,80 +183,121 @@ fun MoreScreen() {
             }
         }
 
-        // Calendar grid showing hours of the day
+        // Calendar grid showing hours of the day with class blocks
         val lineColor = Color(0xFFE0E0E0)
+        val hourHeight = 96.dp
+        val dpPerMinute = hourHeight.value / 60f
+        val minuteGap = dpPerMinute.dp
+        // Show the full day from midnight to 11 pm
         val hours = (0..23).map { hour ->
             val displayHour = if (hour % 12 == 0) 12 else hour % 12
             val ampm = if (hour < 12) "am" else "pm"
             "%02d:00 %s".format(displayHour, ampm)
         }
         val calendarScroll = rememberScrollState()
-        Column(
+        val dayClasses = WEEK_CLASSES[selectedDay] ?: emptyList()
+        BoxWithConstraints(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 16.dp)
+                .height(hourHeight * hours.size)
                 .verticalScroll(calendarScroll)
         ) {
-            hours.forEach { label ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(96.dp)
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .weight(0.2f)
-                            .fillMaxHeight(),
-                    ) {
-                        Text(
-                            text = label,
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = FontWeight.Bold,
+            val labelWidth = maxWidth * 0.2f
+            val contentWidth = maxWidth - labelWidth - 1.dp
+
+            Box {
+                Column {
+                    hours.forEach { label ->
+                        Row(
                             modifier = Modifier
-                                .align(Alignment.TopCenter)
-                                .offset(y = 8.dp)
-                        )
+                                .fillMaxWidth()
+                                .height(hourHeight)
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .width(labelWidth)
+                                    .fillMaxHeight()
+                            ) {
+                                Text(
+                                    text = label,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    fontWeight = FontWeight.Bold,
+                                    modifier = Modifier
+                                        .align(Alignment.TopCenter)
+                                        .offset(y = (-8).dp)
+                                )
+                            }
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxHeight()
+                                    .width(1.dp)
+                                    .background(lineColor)
+                            )
+                            Box(
+                                modifier = Modifier
+                                    .width(contentWidth)
+                                    .fillMaxHeight()
+                            ) {
+                                Divider(
+                                    color = lineColor,
+                                    modifier = Modifier
+                                        .align(Alignment.TopStart)
+                                        .padding(start = 4.dp)
+                                        .fillMaxWidth(),
+                                    thickness = 1.dp
+                                )
+                            }
+                        }
                     }
-                    Box(
-                        modifier = Modifier
-                            .fillMaxHeight()
-                            .width(1.dp)
-                            .background(lineColor)
-                    )
-                    Box(
-                        modifier = Modifier
-                            .weight(0.8f)
-                            .fillMaxHeight()
-                    ) {
-                        Divider(
-                            color = lineColor,
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        Box(modifier = Modifier.width(labelWidth))
+                        Box(
                             modifier = Modifier
-                                .align(Alignment.TopStart)
-                                .padding(start = 4.dp)
-                                .fillMaxWidth(),
-                            thickness = 1.dp
+                                .width(1.dp)
+                                .background(lineColor)
                         )
+                        Box(
+                            modifier = Modifier
+                                .width(contentWidth)
+                        ) {
+                            Divider(
+                                color = lineColor,
+                                modifier = Modifier
+                                    .padding(start = 4.dp)
+                                    .fillMaxWidth(),
+                                thickness = 1.dp
+                            )
+                        }
                     }
                 }
-            }
-            Row(modifier = Modifier.fillMaxWidth()) {
-                Box(modifier = Modifier.weight(0.2f))
-                Box(
-                    modifier = Modifier
-                        .width(1.dp)
-                        .background(lineColor)
-                )
-                Box(
-                    modifier = Modifier
-                        .weight(0.8f)
-                ) {
-                    Divider(
-                        color = lineColor,
+
+                dayClasses.forEach { cls ->
+                    val startMinutes = cls.start.hour * 60 + cls.start.minute
+                    val endMinutes = cls.end.hour * 60 + cls.end.minute
+                    val top = (startMinutes * dpPerMinute).dp + minuteGap
+                    val height = ((endMinutes - startMinutes) * dpPerMinute).dp - minuteGap * 2
+                    val color = when (cls.type) {
+                        ClassType.THEORY -> Color(0xFFD7E8FF)
+                        ClassType.LAB -> Color(0xFFFFF9C4)
+                        ClassType.BREAK, ClassType.LUNCH -> Color(0xFFE0E0E0)
+                    }
+                    Box(
                         modifier = Modifier
-                            .padding(start = 4.dp)
-                            .fillMaxWidth(),
-                        thickness = 1.dp
-                    )
+                            .offset(x = labelWidth + 1.dp + 4.dp, y = top)
+                            .width(contentWidth - 8.dp)
+                            .height(height)
+                            .clip(RoundedCornerShape(6.dp))
+                            .background(color)
+                    ) {
+                        Column(modifier = Modifier.padding(4.dp)) {
+                            Text(cls.title, fontWeight = FontWeight.SemiBold)
+                            Text(
+                                "${cls.start} – ${cls.end}",
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- display calendar hours from midnight to 11pm
- position class blocks with minute precision
- center hour labels and start class cards just below hour lines
- keep a one‑minute gap at the top and bottom of each class card
- fix Dp multiplication in class height calculation
- adjust hour labels so they are bisected by the hour line

## Testing
- `./gradlew test` *(fails: unable to access gradle-wrapper.jar)*
- `./gradlew assembleDebug` *(fails: unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686020bb2754832fadbff421937a847f