### PR TITLE
Update attendance ring colors

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceScreen.kt
@@ -28,17 +28,28 @@ import androidx.compose.ui.unit.dp
 import com.example.basic.DoubleRingProgress
 import com.example.basic.MiniLineGraph
 
-private data class Subject(val name: String, val code: String, val attendance: Float)
+private fun colorForAttendance(value: Float): Color = when {
+    value >= 0.75f -> Color(0xFF55b45e)
+    value >= 0.70f -> Color(0xFFe5a967)
+    else -> Color(0xFFe06846)
+}
+
+private data class Subject(
+    val name: String,
+    val code: String,
+    val total: Float,
+    val between: Float
+)
 
 @Composable
 fun AttendanceScreen() {
     val subjects = listOf(
-        Subject("Mathematics", "MAT101", 0.85f),
-        Subject("Physics", "PHY102", 0.75f),
-        Subject("Chemistry", "CHE103", 0.60f),
-        Subject("Computer Science", "CSE104", 0.95f),
-        Subject("English", "ENG105", 0.80f),
-        Subject("Electronics", "ELE106", 0.50f)
+        Subject("Mathematics", "MAT101", total = 1.0f, between = 1.0f),
+        Subject("Physics", "PHY102", total = 0.72f, between = 0.69f),
+        Subject("Chemistry", "CHE103", total = 0.60f, between = 0.50f),
+        Subject("Computer Science", "CSE104", total = 0.95f, between = 0.85f),
+        Subject("English", "ENG105", total = 0.80f, between = 0.70f),
+        Subject("Electronics", "ELE106", total = 0.50f, between = 0.40f)
     )
 
     Column(
@@ -93,22 +104,18 @@ fun AttendanceScreen() {
                         modifier = Modifier.align(Alignment.CenterVertically),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        val progressColor = when {
-                            subject.attendance >= 0.75f -> Color(0xFF55b45e)
-                            subject.attendance >= 0.70f -> Color(0xFFe5a967)
-                            else -> Color(0xFFe06846)
-                        }
-                        val inner = (subject.attendance - 0.1f).coerceAtLeast(0f)
+                        val outerColor = colorForAttendance(subject.total)
+                        val innerColor = colorForAttendance(subject.between)
                         DoubleRingProgress(
-                            outerProgress = subject.attendance,
-                            innerProgress = inner,
+                            outerProgress = subject.total,
+                            innerProgress = subject.between,
                             modifier = Modifier.size(96.dp),
-                            color = progressColor,
-                            trackColor = progressColor.copy(alpha = 0.3f)
+                            outerColor = outerColor,
+                            innerColor = innerColor
                         )
                         Spacer(modifier = Modifier.height(8.dp))
                         Text(
-                            text = "Btw exams: ${(inner * 100).toInt()}%",
+                            text = "Btw exams: ${(subject.between * 100).toInt()}%",
                             style = MaterialTheme.typography.bodyLarge,
                             color = Color.Gray,
                             fontWeight = FontWeight.Bold

--- a/app/src/main/java/com/example/basic/DoubleRingProgress.kt
+++ b/app/src/main/java/com/example/basic/DoubleRingProgress.kt
@@ -22,8 +22,8 @@ fun DoubleRingProgress(
     outerProgress: Float,
     innerProgress: Float,
     modifier: Modifier = Modifier,
-    color: Color = Color(0xFF3F51B5),
-    trackColor: Color = color.copy(alpha = 0.3f),
+    outerColor: Color = Color(0xFF3F51B5),
+    innerColor: Color = outerColor,
     thickness: Dp = 8.dp,
     gap: Dp = 4.dp
 ) {
@@ -34,10 +34,12 @@ fun DoubleRingProgress(
             val gapPx = gap.toPx()
             val outerRadius = size.minDimension / 2
             val innerRadius = outerRadius - strokeWidth - gapPx
+            val outerTrackColor = outerColor.copy(alpha = 0.3f)
+            val innerTrackColor = innerColor.copy(alpha = 0.3f)
 
             // Outer track
             drawArc(
-                color = trackColor,
+                color = outerTrackColor,
                 startAngle = -90f,
                 sweepAngle = 360f,
                 useCenter = false,
@@ -48,7 +50,7 @@ fun DoubleRingProgress(
 
             // Outer progress
             drawArc(
-                color = color,
+                color = outerColor,
                 startAngle = -90f,
                 sweepAngle = 360f * outerProgress.coerceIn(0f, 1f),
                 useCenter = false,
@@ -59,7 +61,7 @@ fun DoubleRingProgress(
 
             // Inner track
             drawArc(
-                color = trackColor,
+                color = innerTrackColor,
                 startAngle = -90f,
                 sweepAngle = 360f,
                 useCenter = false,
@@ -70,7 +72,7 @@ fun DoubleRingProgress(
 
             // Inner progress
             drawArc(
-                color = color,
+                color = innerColor,
                 startAngle = -90f,
                 sweepAngle = 360f * innerProgress.coerceIn(0f, 1f),
                 useCenter = false,


### PR DESCRIPTION
## Summary
- color inner ring based on between exam attendance
- return color utility for attendance percentage

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68602ebc75a4832fb1fdd7f93976af92