### PR TITLE
Fix hour label alignment

### DIFF
--- a/app/src/main/java/com/example/basic/MoreScreen.kt
+++ b/app/src/main/java/com/example/basic/MoreScreen.kt
@@ -234,7 +234,9 @@ fun MoreScreen() {
                                     fontWeight = FontWeight.Bold,
                                     modifier = Modifier
                                         .align(Alignment.TopCenter)
-                                        .offset(y = (-8).dp)
+                                        // Shift labels slightly higher so
+                                        // they line up with the hour divider
+                                        .offset(y = (-12).dp)
                                 )
                             }
                             Box(


### PR DESCRIPTION
## Summary
- tweak hour label offset in More screen

## Testing
- `./gradlew test` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_686034d428bc832fa8882d5552e54632