### PR TITLE
Switch to downloadable Inter fonts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation 'androidx.compose.ui:ui-tooling-preview'
     debugImplementation 'androidx.compose.ui:ui-tooling'
     implementation 'androidx.compose.foundation:foundation'
+    implementation 'androidx.compose.ui:ui-text-google-fonts'
     implementation 'androidx.compose.material3:material3'
     implementation 'androidx.compose.material:material-icons-extended'
     implementation 'androidx.constraintlayout:constraintlayout-compose:1.0.1'

--- a/app/src/main/java/com/example/basic/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/basic/ui/theme/Theme.kt
@@ -1,10 +1,33 @@
 package com.example.basic.ui.theme
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Typography
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.googlefonts.GoogleFont
+import androidx.compose.ui.text.googlefonts.GoogleFont.Provider
+import com.example.basic.R
+
+private val googleFontProvider = Provider(
+    authority = "com.google.android.gms.fonts",
+    package = "com.google.android.gms",
+    certificates = R.array.com_google_android_gms_fonts_certs
+)
+
+private val interFontName = GoogleFont("Inter")
+
+private val Inter = FontFamily(
+    Font(googleFont = interFontName, fontProvider = googleFontProvider, weight = FontWeight.Normal),
+    Font(googleFont = interFontName, fontProvider = googleFontProvider, weight = FontWeight.Medium),
+    Font(googleFont = interFontName, fontProvider = googleFontProvider, weight = FontWeight.Bold),
+)
+
+private val AppTypography = Typography(defaultFontFamily = Inter)
 
 @Composable
 fun VitStudentAppTheme(content: @Composable () -> Unit) {
-    MaterialTheme(colorScheme = lightColorScheme(), content = content)
+    MaterialTheme(colorScheme = lightColorScheme(), typography = AppTypography, content = content)
 }


### PR DESCRIPTION
## Summary
- download Inter from Google Fonts at runtime instead of storing TTF files
- configure Typography to use this downloadable font
- add Compose Google Fonts dependency

## Testing
- `./gradlew test` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_686101bf1798832f97dc98ea621f242e