### PR TITLE
Add Play Services Basement dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,5 +54,6 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout-compose:1.0.1'
     implementation 'androidx.navigation:navigation-compose:2.7.7'
     implementation 'io.coil-kt:coil-compose:2.4.0'
+    implementation 'com.google.android.gms:play-services-basement:18.4.0'
     implementation 'com.google.android.material:material:1.11.0'
 }


### PR DESCRIPTION
## Summary
- add missing `play-services-basement` library in `app/build.gradle`
- run `gradle clean` to verify dependency resolution

## Testing
- `gradle clean`

------
https://chatgpt.com/codex/tasks/task_e_68612646d968832fae3fcdaee8b0f1eb