### PR TITLE
Update fonts loading to local Inter

### DIFF
--- a/vit-student-app/App.tsx
+++ b/vit-student-app/App.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { useFonts, Inter_400Regular } from '@expo-google-fonts/inter';
+import { useFonts } from 'expo-font';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { NavigationContainer } from '@react-navigation/native';
 import {
@@ -136,14 +136,14 @@ function MainTabs() {
 
 export default function App() {
   const [fontsLoaded] = useFonts({
-    Inter_400Regular,
+    Inter: require('./font/Inter-VariableFont_opsz,wght.ttf'),
   });
 
   React.useEffect(() => {
     if (fontsLoaded) {
       (Text as any).defaultProps = (Text as any).defaultProps || {};
       (Text as any).defaultProps.style = [
-        { fontFamily: 'Inter_400Regular' },
+        { fontFamily: 'Inter' },
         (Text as any).defaultProps.style,
       ];
     }

--- a/vit-student-app/package-lock.json
+++ b/vit-student-app/package-lock.json
@@ -8,7 +8,6 @@
       "name": "vit-student-app",
       "version": "1.0.0",
       "dependencies": {
-        "@expo-google-fonts/inter": "^0.3.0",
         "@expo/metro-runtime": "~5.0.4",
         "@expo/vector-icons": "^14.1.0",
         "@react-native-async-storage/async-storage": "^2.1.2",
@@ -1544,12 +1543,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/@expo-google-fonts/inter": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@expo-google-fonts/inter/-/inter-0.3.0.tgz",
-      "integrity": "sha512-x77HsdpizmZFNZ8nMd7hsNah/MyxhLmihZQEyIkB473jskBcXIpsyf+tVVLXvXEhtnpGx8zZ2XAe9u+i0qvIEw==",
-      "license": "MIT"
     },
     "node_modules/@expo/cli": {
       "version": "0.24.15",

--- a/vit-student-app/package.json
+++ b/vit-student-app/package.json
@@ -33,7 +33,6 @@
     "expo-sensors": "~14.1.4",
     "expo-status-bar": "~2.2.3",
     "expo-font": "~13.3.1",
-    "@expo-google-fonts/inter": "^0.3.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.3",


### PR DESCRIPTION
## Summary
- remove @expo-google-fonts/inter dependency
- load Inter font from local file via expo-font
- set default `Text` font family to Inter

## Testing
- `npx tsc --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_68612a11f574832f9982c8b75d12e9ea