### PR TITLE
Handle Inter font without binary file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ local.properties
 
 # Gradle wrapper
 gradle/wrapper/gradle-wrapper.jar
+
+# Local fonts
+app/src/main/res/font/inter.ttf

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ available on your system and then execute:
 ./gradlew assembleDebug
 ```
 
+During the build the Inter font is copied from
+`vit-student-app/font/Inter-VariableFont_opsz,wght.ttf` into
+`app/src/main/res/font`. The font file itself is not tracked in git to keep the
+repository lightweight.
+
 The project now uses the Gradle plugin DSL and a modern plugin management
 configuration. This removes deprecation warnings that appeared with newer
 versions of Gradle.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,13 +47,20 @@ dependencies {
     implementation 'androidx.compose.ui:ui-tooling-preview'
     debugImplementation 'androidx.compose.ui:ui-tooling'
     implementation 'androidx.compose.foundation:foundation'
-    implementation 'androidx.compose.ui:ui-text-google-fonts:1.5.4'
-    implementation 'com.google.android.gms:play-services-base:18.4.0'
     implementation 'androidx.compose.material3:material3'
     implementation 'androidx.compose.material:material-icons-extended'
     implementation 'androidx.constraintlayout:constraintlayout-compose:1.0.1'
     implementation 'androidx.navigation:navigation-compose:2.7.7'
     implementation 'io.coil-kt:coil-compose:2.4.0'
-    implementation 'com.google.android.gms:play-services-basement:18.4.0'
     implementation 'com.google.android.material:material:1.11.0'
 }
+
+// Automatically copy the Inter font from the vit-student-app directory.
+// This avoids committing the binary font file into source control.
+tasks.register('prepareInterFont', Copy) {
+    from("${rootDir}/vit-student-app/font/Inter-VariableFont_opsz,wght.ttf")
+    into("${projectDir}/src/main/res/font")
+    rename { 'inter.ttf' }
+}
+
+preBuild.dependsOn(prepareInterFont)

--- a/app/src/main/java/com/example/basic/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/basic/ui/theme/Theme.kt
@@ -5,18 +5,10 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.googlefonts.GoogleFont
-import androidx.compose.ui.text.googlefonts.GoogleFont.Provider
-import androidx.compose.ui.text.googlefonts.Font
-import com.google.android.gms.R as GmsR
+import androidx.compose.ui.text.font.Font
+import com.example.basic.R
 
-private val provider = Provider(
-    providerAuthority = "com.google.android.gms.fonts",
-    providerPackage = "com.google.android.gms",
-    certificates = GmsR.array.com_google_android_gms_fonts_certs
-)
-
-private val Inter = FontFamily(Font(GoogleFont("Inter"), provider))
+private val Inter = FontFamily(Font(R.font.inter))
 
 private val DefaultTypography = Typography()
 


### PR DESCRIPTION
## Summary
- ignore `inter.ttf` so binary font isn't checked in
- copy Inter font at build time with a Gradle task
- update README with font preparation details

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_686129d95df4832f97f05af9e26b3096