### PR TITLE
Fix label wrapping in bottom navigation

### DIFF
--- a/app/src/main/java/com/example/basic/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/basic/navigation/AppNavHost.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -120,7 +121,13 @@ fun AppNavHost() {
                             val iconModifier = if (screen == Screen.Home) Modifier.size(32.dp) else Modifier
                             Icon(iconImage, contentDescription = screen.label, modifier = iconModifier)
                         },
-                        label = { Text(screen.label) },
+                        label = {
+                            Text(
+                                screen.label,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        },
                         selected = selected,
                         onClick = {
                             when (screen) {


### PR DESCRIPTION
## Summary
- ensure bottom nav labels don't wrap

## Testing
- `npm test` *(fails: Missing script)*
- `./gradlew assembleDebug` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_68612cdb26b8832fba57a6be52cf8868