### PR TITLE
Improve calendar style and unify headings

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceDetailsScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceDetailsScreen.kt
@@ -121,7 +121,13 @@ fun AttendanceDetailsScreen(onBack: () -> Unit) {
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             CenterAlignedTopAppBar(
-                title = { Text("Schedule", fontWeight = FontWeight.Bold) },
+                title = {
+                    Text(
+                        "Schedule",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+                },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.Default.ArrowBack, contentDescription = "Back")

--- a/app/src/main/java/com/example/basic/AttendanceScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceScreen.kt
@@ -60,6 +60,12 @@ fun AttendanceScreen() {
             .verticalScroll(rememberScrollState())
             .padding(16.dp)
     ) {
+        Text(
+            text = "Attendance",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
         subjects.forEach { subject ->
             Card(
                 modifier = Modifier

--- a/app/src/main/java/com/example/basic/FoodSummaryScreen.kt
+++ b/app/src/main/java/com/example/basic/FoodSummaryScreen.kt
@@ -16,11 +16,19 @@ fun FoodSummaryScreen(onBack: () -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
+            .background(MaterialTheme.colorScheme.background)
+            .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
+        Text(
+            text = "Food Summary",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.height(16.dp))
         Text(text = "Food Summary page coming soon.", style = MaterialTheme.typography.bodyLarge)
+        Spacer(modifier = Modifier.height(16.dp))
         Button(onClick = onBack) { Text("Back") }
     }
 }

--- a/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
@@ -160,6 +160,7 @@ fun MonthlyMenuScreen(onBack: () -> Unit) {
                 title = {
                     Text(
                         "Monthly Menu",
+                        style = MaterialTheme.typography.titleLarge,
                         fontWeight = FontWeight.Bold,
                         textAlign = TextAlign.Center,
                         modifier = Modifier.fillMaxWidth()

--- a/app/src/main/java/com/example/basic/MoreScreen.kt
+++ b/app/src/main/java/com/example/basic/MoreScreen.kt
@@ -93,7 +93,8 @@ fun MoreScreen() {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
+            .background(MaterialTheme.colorScheme.background)
+            .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
@@ -109,8 +110,7 @@ fun MoreScreen() {
         )
         Row(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
+                .fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceEvenly
         ) {
             weekDates.forEach { date ->
@@ -304,6 +304,7 @@ fun MoreScreen() {
                             .offset(x = labelWidth + 1.dp + 4.dp, y = top)
                             .width(contentWidth - 8.dp)
                             .height(height)
+                            .shadow(4.dp, RoundedCornerShape(6.dp))
                             .clip(RoundedCornerShape(6.dp))
                             .background(color)
                     ) {

--- a/app/src/main/java/com/example/basic/PlannerScreen.kt
+++ b/app/src/main/java/com/example/basic/PlannerScreen.kt
@@ -45,6 +45,7 @@ fun PlannerScreen() {
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
+            .padding(16.dp)
             .pointerInput(dayIndex) {
                 detectHorizontalDragGestures(
                     onHorizontalDrag = { _, delta ->
@@ -64,11 +65,10 @@ fun PlannerScreen() {
     ) {
         Text(
             text = "Weekly Timetable",
-            style = MaterialTheme.typography.headlineSmall,
+            style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
             color = Color(0xFF333333),
-            modifier = Modifier
-                .padding(vertical = 16.dp, horizontal = 16.dp)
+            modifier = Modifier.padding(vertical = 16.dp)
         )
 
         LazyRow(


### PR DESCRIPTION
## Summary
- add padding to calendar screen and planner
- add shadow to calendar classes
- standardize heading styles across screens
- improve layout consistency across pages

## Testing
- `./gradlew tasks --no-daemon` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_686132f368c8832fa7a96c7802d2380f