### PR TITLE
Update palette

### DIFF
--- a/app/src/main/java/com/example/basic/DoubleRingProgress.kt
+++ b/app/src/main/java/com/example/basic/DoubleRingProgress.kt
@@ -22,7 +22,7 @@ fun DoubleRingProgress(
     outerProgress: Float,
     innerProgress: Float,
     modifier: Modifier = Modifier,
-    outerColor: Color = Color(0xFF3F51B5),
+    outerColor: Color = Color(0xFF69CBFF),
     innerColor: Color = outerColor,
     thickness: Dp = 8.dp,
     gap: Dp = 4.dp

--- a/app/src/main/java/com/example/basic/FoodMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/FoodMenuScreen.kt
@@ -195,10 +195,10 @@ fun FoodMenuScreen(onShowSummary: () -> Unit, onViewMonth: () -> Unit = {}) {
 }
 
 private val mealColors = listOf(
-    Color(0xFFEEF7FF),
-    Color(0xFFE8FFF0),
-    Color(0xFFFFF5E0),
-    Color(0xFFFFEEF0)
+    Color(0xFF69CBFF),
+    Color(0xFF1CDDFE),
+    Color(0xFF69F6BC),
+    Color(0xFFF9F871)
 )
 
 private fun mealIcon(name: String) = when (name.lowercase()) {

--- a/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
@@ -38,18 +38,19 @@ data class DayData(val date: String, val meals: List<Meal>)
 
 data class WeekSection(val title: String, val color: Color, val dayColor: Color, val days: List<DayData>)
 
+// New palette colors
 private val WEEK_COLORS = listOf(
-    Color(0xFFF0E4D7),
-    Color(0xFFE7F0D7),
-    Color(0xFFD7E8F0),
-    Color(0xFFF0D7E8)
+    Color(0xFF69CBFF),
+    Color(0xFF1CDDFE),
+    Color(0xFF0DECE3),
+    Color(0xFF69F6BC)
 )
 
 private val DAY_COLORS = listOf(
-    Color(0xFFE5D7CB),
-    Color(0xFFDCE5CB),
-    Color(0xFFCBDCE5),
-    Color(0xFFE5CBDC)
+    Color(0xFF69CBFF),
+    Color(0xFF1CDDFE),
+    Color(0xFFB2FB91),
+    Color(0xFFF9F871)
 )
 
 private fun parseMonthlyMenu(json: String): MonthlyMenu {

--- a/app/src/main/java/com/example/basic/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/basic/ui/theme/Color.kt
@@ -2,12 +2,13 @@ package com.example.basic.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val mdPrimary = Color(0xFF3F51B5)
-val mdSecondary = Color(0xFF009688)
-val mdBackground = Color(0xFFF8F8F8)
-val mdSurface = Color.White
-val mdOnPrimary = Color.White
-val mdOnSecondary = Color.White
+// Updated palette based on new design
+val mdPrimary = Color(0xFF69CBFF)      // #69cbff
+val mdSecondary = Color(0xFF1CDDFE)    // #1cddfe
+val mdBackground = Color(0xFF0DECE3)   // #0dece3
+val mdSurface = Color(0xFF69F6BC)      // #69f6bc
+val mdOnPrimary = Color(0xFFB2FB91)    // #b2fb91
+val mdOnSecondary = Color(0xFFF9F871)  // #f9f871
 val mdOnBackground = Color(0xFF333333)
 val mdOnSurface = Color(0xFF333333)
 val mdError = Color(0xFFB00020)

--- a/vit-student-app/src/components/AnimatedWaterText.tsx
+++ b/vit-student-app/src/components/AnimatedWaterText.tsx
@@ -27,7 +27,7 @@ type Props = {
 export default function AnimatedWaterText({
   text,
   fontSize,
-  fillColor = '#66ccff',
+  fillColor = '#69cbff',
   containerWidth = SCREEN_WIDTH * 0.8,
   containerHeight = fontSize * 1.2,
 }: Props) {

--- a/vit-student-app/src/components/FullMenuPanel.tsx
+++ b/vit-student-app/src/components/FullMenuPanel.tsx
@@ -53,7 +53,7 @@ const styles = StyleSheet.create({
   },
   backText: {
     fontSize: 16,
-    color: '#007bff',
+    color: '#69cbff',
     marginRight: 12,
   },
   title: {

--- a/vit-student-app/src/components/RatingModal.tsx
+++ b/vit-student-app/src/components/RatingModal.tsx
@@ -110,7 +110,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#ddd',
   },
   submitButton: {
-    backgroundColor: '#007bff',
+    backgroundColor: '#69cbff',
   },
   cancelText: {
     color: '#333',

--- a/vit-student-app/src/components/WhatsNextPanel.tsx
+++ b/vit-student-app/src/components/WhatsNextPanel.tsx
@@ -299,7 +299,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     bottom: 12,
     right: 16,
-    backgroundColor: '#007bff',
+    backgroundColor: '#69cbff',
     paddingVertical: 8,
     paddingHorizontal: 12,
     borderRadius: 8,

--- a/vit-student-app/src/screens/FoodMenuScreen.tsx
+++ b/vit-student-app/src/screens/FoodMenuScreen.tsx
@@ -400,7 +400,7 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
 
-    backgroundColor: '#007bff',
+    backgroundColor: '#69cbff',
 
     borderTopColor: '#ddd',
     borderTopWidth: StyleSheet.hairlineWidth,


### PR DESCRIPTION
## Summary
- redesign palette with light blues and greens
- update progress indicator and month/week colors
- change React Native blue accents

## Testing
- `./gradlew tasks --all` *(fails: Unable to access jarfile)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68613bfc43d0832f86811ca9b1ddcfd4