### PR TITLE
Simplify food page colors

### DIFF
--- a/app/src/main/java/com/example/basic/DoubleRingProgress.kt
+++ b/app/src/main/java/com/example/basic/DoubleRingProgress.kt
@@ -22,7 +22,7 @@ fun DoubleRingProgress(
     outerProgress: Float,
     innerProgress: Float,
     modifier: Modifier = Modifier,
-    outerColor: Color = Color(0xFF3F51B5),
+    outerColor: Color = Color(0xFF69CBFF),
     innerColor: Color = outerColor,
     thickness: Dp = 8.dp,
     gap: Dp = 4.dp

--- a/app/src/main/java/com/example/basic/FoodMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/FoodMenuScreen.kt
@@ -195,10 +195,10 @@ fun FoodMenuScreen(onShowSummary: () -> Unit, onViewMonth: () -> Unit = {}) {
 }
 
 private val mealColors = listOf(
-    Color(0xFFEEF7FF),
-    Color(0xFFE8FFF0),
-    Color(0xFFFFF5E0),
-    Color(0xFFFFEEF0)
+    Color.White,
+    Color.White,
+    Color.White,
+    Color.White
 )
 
 private fun mealIcon(name: String) = when (name.lowercase()) {
@@ -244,10 +244,10 @@ private fun MealCard(
                 Spacer(modifier = Modifier.width(6.dp))
                 Text(
                     text = meal.name,
-                    color = MaterialTheme.colorScheme.onPrimary,
+                    color = MaterialTheme.colorScheme.onBackground,
                     style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier
-                        .background(MaterialTheme.colorScheme.primary, RoundedCornerShape(12.dp))
+                        .background(MaterialTheme.colorScheme.surface, RoundedCornerShape(12.dp))
                         .padding(horizontal = 8.dp, vertical = 2.dp)
                 )
                 Spacer(modifier = Modifier.width(8.dp))
@@ -303,11 +303,11 @@ private fun MealCard(
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                 Button(
                     onClick = onRate,
-                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
                 ) {
-                    Icon(Icons.Default.Star, contentDescription = null, tint = MaterialTheme.colorScheme.onSecondaryContainer, modifier = Modifier.size(16.dp))
+                    Icon(Icons.Default.Star, contentDescription = null, tint = MaterialTheme.colorScheme.onPrimary, modifier = Modifier.size(16.dp))
                     Spacer(Modifier.width(4.dp))
-                    Text("Rate", color = MaterialTheme.colorScheme.onSecondaryContainer)
+                    Text("Rate", color = MaterialTheme.colorScheme.onPrimary)
                 }
             }
         }

--- a/app/src/main/java/com/example/basic/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/basic/ui/theme/Color.kt
@@ -2,9 +2,10 @@ package com.example.basic.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val mdPrimary = Color(0xFF3F51B5)
-val mdSecondary = Color(0xFF009688)
-val mdBackground = Color(0xFFF8F8F8)
+// Minimalist palette – mostly white with light blue accents
+val mdPrimary = Color(0xFF69CBFF)      // accent blue
+val mdSecondary = Color(0xFF1CDDFE)    // secondary accent
+val mdBackground = Color.White
 val mdSurface = Color.White
 val mdOnPrimary = Color.White
 val mdOnSecondary = Color.White

--- a/vit-student-app/src/components/AnimatedWaterText.tsx
+++ b/vit-student-app/src/components/AnimatedWaterText.tsx
@@ -27,7 +27,7 @@ type Props = {
 export default function AnimatedWaterText({
   text,
   fontSize,
-  fillColor = '#66ccff',
+  fillColor = '#69cbff',
   containerWidth = SCREEN_WIDTH * 0.8,
   containerHeight = fontSize * 1.2,
 }: Props) {

--- a/vit-student-app/src/components/FullMenuPanel.tsx
+++ b/vit-student-app/src/components/FullMenuPanel.tsx
@@ -53,7 +53,7 @@ const styles = StyleSheet.create({
   },
   backText: {
     fontSize: 16,
-    color: '#007bff',
+    color: '#69cbff',
     marginRight: 12,
   },
   title: {

--- a/vit-student-app/src/components/RatingModal.tsx
+++ b/vit-student-app/src/components/RatingModal.tsx
@@ -110,7 +110,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#ddd',
   },
   submitButton: {
-    backgroundColor: '#007bff',
+    backgroundColor: '#69cbff',
   },
   cancelText: {
     color: '#333',

--- a/vit-student-app/src/components/WhatsNextPanel.tsx
+++ b/vit-student-app/src/components/WhatsNextPanel.tsx
@@ -299,7 +299,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     bottom: 12,
     right: 16,
-    backgroundColor: '#007bff',
+    backgroundColor: '#69cbff',
     paddingVertical: 8,
     paddingHorizontal: 12,
     borderRadius: 8,

--- a/vit-student-app/src/screens/FoodMenuScreen.tsx
+++ b/vit-student-app/src/screens/FoodMenuScreen.tsx
@@ -108,7 +108,7 @@ export default function FoodMenuScreen() {
     day: 'numeric',
   });
   const meals = menu?.[todayKey];
-  const mealColors = ['#ffeef0', '#eef7ff', '#e8fff0', '#fff5e0'];
+  const mealColors = ['#ffffff', '#ffffff', '#ffffff', '#ffffff'];
 
   if (loading) {
     return (
@@ -212,7 +212,7 @@ export default function FoodMenuScreen() {
               },
             ]}
           >
-          <Ionicons name="restaurant" size={24} color="#ff6347" />
+          <Ionicons name="restaurant" size={24} color="#69cbff" />
           </Animated.View>
         </View>
         <View style={styles.dateChip}>
@@ -260,7 +260,7 @@ export default function FoodMenuScreen() {
                     <Ionicons
                       name={mealIcon(m.name)}
                       size={16}
-                      color="#ffa500"
+                      color="#69cbff"
                       style={styles.mealIcon}
                     />
                   </Animated.View>
@@ -331,7 +331,7 @@ export default function FoodMenuScreen() {
 const styles = StyleSheet.create({
   safe: {
     flex: 1,
-    backgroundColor: '#f5f5f5',
+    backgroundColor: '#ffffff',
   },
   container: {
     padding: 16,
@@ -348,14 +348,16 @@ const styles = StyleSheet.create({
   centered: { flex: 1, justifyContent: 'center', alignItems: 'center' },
   dateChip: {
     alignSelf: 'center',
-    backgroundColor: '#000',
+    backgroundColor: '#ffffff',
     paddingVertical: 4,
     paddingHorizontal: 12,
     borderRadius: 20,
     marginBottom: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#ccc',
   },
   dateChipText: {
-    color: '#fff',
+    color: '#333',
     fontWeight: '600',
   },
   mealBlock: {
@@ -384,11 +386,13 @@ const styles = StyleSheet.create({
   mealTitle: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#fff',
-    backgroundColor: '#333',
+    color: '#333',
+    backgroundColor: '#ffffff',
     paddingHorizontal: 8,
     paddingVertical: 2,
     borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#ccc',
   },
   mealHeaderRight: {
     flexDirection: 'row',
@@ -400,7 +404,7 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
 
-    backgroundColor: '#007bff',
+    backgroundColor: '#69cbff',
 
     borderTopColor: '#ddd',
     borderTopWidth: StyleSheet.hairlineWidth,
@@ -438,7 +442,7 @@ const styles = StyleSheet.create({
   },
   rateButton: {
     flexDirection: 'row',
-    backgroundColor: '#ff6347',
+    backgroundColor: '#69cbff',
     paddingHorizontal: 12,
     paddingVertical: 6,
     borderRadius: 8,
@@ -456,7 +460,7 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     paddingHorizontal: 16,
     borderRadius: 8,
-    backgroundColor: '#ff6347',
+    backgroundColor: '#69cbff',
     alignItems: 'center',
     flexDirection: 'row',
     alignSelf: 'center',

--- a/vit-student-app/src/screens/Home.tsx
+++ b/vit-student-app/src/screens/Home.tsx
@@ -122,7 +122,7 @@ export default function Home() {
       style={[
         styles.root,
         {
-          backgroundColor: '#f0f0f0',
+          backgroundColor: '#ffffff',
           paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0,
         },
       ]}


### PR DESCRIPTION
## Summary
- keep meal cards white in Compose screen
- remove tinted meal chips
- set white safe area, date chip and meal labels in React screen
- switch rating buttons to light blue accent
- use white background on the home screen

## Testing
- `./gradlew tasks --all` *(fails: Unable to access jarfile)*
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68613bfc43d0832f86811ca9b1ddcfd4