### PR TITLE
Improve typography across app

### DIFF
--- a/app/src/main/java/com/example/basic/AttendanceDetailsScreen.kt
+++ b/app/src/main/java/com/example/basic/AttendanceDetailsScreen.kt
@@ -280,13 +280,13 @@ private fun DaySelector(
                 Text(
                     day.date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
                     color = textColor,
-                    style = MaterialTheme.typography.labelSmall,
+                    style = MaterialTheme.typography.labelMedium,
                     fontWeight = FontWeight.Bold
                 )
                 Text(
                     day.date.dayOfMonth.toString(),
                     color = textColor,
-                    style = MaterialTheme.typography.labelSmall,
+                    style = MaterialTheme.typography.labelMedium,
                     fontWeight = FontWeight.Bold
                 )
             }
@@ -376,7 +376,7 @@ private fun ScheduleList(date: LocalDate, events: List<ClassEvent>) {
                         Text(
                             displayTime,
                             color = timeColor,
-                            style = MaterialTheme.typography.labelSmall,
+                            style = MaterialTheme.typography.labelMedium,
                             maxLines = 1,
                             modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
                         )
@@ -444,7 +444,7 @@ private fun EventCard(event: ClassEvent, modifier: Modifier = Modifier) {
                 Text(
                     event.category.label,
                     color = Color.White.copy(alpha = 0.9f),
-                    style = MaterialTheme.typography.labelSmall
+                    style = MaterialTheme.typography.labelMedium
                 )
             }
         }

--- a/app/src/main/java/com/example/basic/CardCarousel.kt
+++ b/app/src/main/java/com/example/basic/CardCarousel.kt
@@ -158,7 +158,7 @@ private fun NumberRowAnimated(
                 Text(
                     text = "${idx + 1}",
                     color = Color.White,
-                    style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.SemiBold),
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
                     modifier = Modifier.graphicsLayer(scaleX = animNum, scaleY = animNum)
                 )
             }

--- a/app/src/main/java/com/example/basic/FoodMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/FoodMenuScreen.kt
@@ -260,7 +260,7 @@ private fun MealCard(
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
                     text = String.format("%02d:%02d - %02d:%02d", meal.startHour, meal.startMinute, meal.endHour, meal.endMinute),
-                    style = MaterialTheme.typography.bodySmall,
+                    style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onBackground
                 )
                 Spacer(Modifier.weight(1f))
@@ -272,7 +272,7 @@ private fun MealCard(
                         modifier = Modifier.size(16.dp)
                     )
                     Spacer(Modifier.width(4.dp))
-                    Text(text = if (ended) "Done" else status, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onBackground)
+                    Text(text = if (ended) "Done" else status, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onBackground)
                     if (!ended) {
                         Spacer(Modifier.width(8.dp))
                         val target = if (status == "Upcoming") start.timeInMillis else end.timeInMillis
@@ -281,7 +281,7 @@ private fun MealCard(
                         val m = (diff % 3600000) / 60000
                         val s = (diff % 60000) / 1000
                         val timer = if (h > 0) String.format("%02d:%02d:%02d", h, m, s) else String.format("%02d:%02d", m, s)
-                        Text(timer, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onBackground)
+                        Text(timer, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onBackground)
                     }
                     Spacer(Modifier.width(8.dp))
                     Icon(
@@ -305,7 +305,7 @@ private fun MealCard(
                 }
             }
             Spacer(modifier = Modifier.height(4.dp))
-            Text(text = meal.items.joinToString(", "), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f))
+            Text(text = meal.items.joinToString(", "), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f))
             Spacer(modifier = Modifier.height(8.dp))
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                 Button(

--- a/app/src/main/java/com/example/basic/HomeScreen.kt
+++ b/app/src/main/java/com/example/basic/HomeScreen.kt
@@ -220,7 +220,7 @@ fun HomeHeader(modifier: Modifier = Modifier) {
             )
             Text(
                 date,
-                style = MaterialTheme.typography.bodySmall
+                style = MaterialTheme.typography.bodyMedium
             )
         }
         Box(

--- a/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
+++ b/app/src/main/java/com/example/basic/MonthlyMenuScreen.kt
@@ -307,7 +307,7 @@ private fun DayCard(
                             .clickable { onAdd(key) }
                     )
                 }
-                Text(meal.items.joinToString(", "), style = MaterialTheme.typography.bodySmall)
+                Text(meal.items.joinToString(", "), style = MaterialTheme.typography.bodyMedium)
                 if (index != day.meals.lastIndex) Spacer(Modifier.height(8.dp))
             }
         }

--- a/app/src/main/java/com/example/basic/MoreScreen.kt
+++ b/app/src/main/java/com/example/basic/MoreScreen.kt
@@ -314,7 +314,7 @@ fun MoreScreen() {
                             Text(cls.title, fontWeight = FontWeight.SemiBold)
                             Text(
                                 "${cls.start} – ${cls.end}",
-                                style = MaterialTheme.typography.bodySmall
+                                style = MaterialTheme.typography.bodyMedium
                             )
                         }
                     }

--- a/app/src/main/java/com/example/basic/PlannerScreen.kt
+++ b/app/src/main/java/com/example/basic/PlannerScreen.kt
@@ -148,7 +148,7 @@ fun PlannerScreen() {
                             )
                             Text(
                                 text = cls.faculty,
-                                style = MaterialTheme.typography.bodySmall,
+                                style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
                                 modifier = Modifier.padding(top = 2.dp)
                             )
@@ -156,12 +156,12 @@ fun PlannerScreen() {
                         Column(horizontalAlignment = Alignment.End) {
                             Text(
                                 text = "${cls.start} – ${cls.end}",
-                                style = MaterialTheme.typography.bodySmall,
+                                style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onBackground
                             )
                             Text(
                                 text = cls.room,
-                                style = MaterialTheme.typography.labelSmall,
+                                style = MaterialTheme.typography.labelMedium,
                                 color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
                                 modifier = Modifier.padding(top = 2.dp)
                             )

--- a/app/src/main/java/com/example/basic/SummaryCard.kt
+++ b/app/src/main/java/com/example/basic/SummaryCard.kt
@@ -159,7 +159,7 @@ private fun WeatherCard() {
                 Text(
                     "Feels like 27°",
                     color = Color.White,
-                    style = MaterialTheme.typography.labelSmall,
+                    style = MaterialTheme.typography.labelMedium,
                     modifier = Modifier.offset(x = (-10).dp, y = (-10).dp)
                 )
             }
@@ -189,7 +189,7 @@ private fun WeatherInfo(value: String, label: String) {
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold
         )
-        Text(label, color = Color.White, style = MaterialTheme.typography.labelSmall)
+        Text(label, color = Color.White, style = MaterialTheme.typography.labelMedium)
     }
 }
 
@@ -282,7 +282,7 @@ private fun MenuSection(contentPadding: Dp) {
                             )
                             Text(
                                 menu,
-                                style = MaterialTheme.typography.bodySmall,
+                                style = MaterialTheme.typography.bodyMedium,
                                 modifier = Modifier.padding(top = 4.dp),
                                 textAlign = TextAlign.Center
                             )
@@ -378,7 +378,7 @@ private fun TasksSection() {
                             )
                             Text(
                                 task.details,
-                                style = MaterialTheme.typography.bodySmall,
+                                style = MaterialTheme.typography.bodyMedium,
                                 color = Color(0xFF666666),
                                 textDecoration = if (checked) TextDecoration.LineThrough else TextDecoration.None
                             )
@@ -386,7 +386,7 @@ private fun TasksSection() {
                     }
                     Text(
                         task.priority.label,
-                        style = MaterialTheme.typography.labelSmall,
+                        style = MaterialTheme.typography.labelMedium,
                         color = accent,
                         modifier = Modifier
                             .align(Alignment.BottomEnd)

--- a/app/src/main/java/com/example/basic/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/basic/ui/theme/Theme.kt
@@ -23,21 +23,21 @@ private val Inter = FontFamily(Font(R.font.inter))
 private val DefaultTypography = Typography()
 
 private val AppTypography = Typography(
-    displayLarge = TextStyle(fontFamily = Inter, fontSize = 40.sp),
-    displayMedium = TextStyle(fontFamily = Inter, fontSize = 34.sp),
-    displaySmall = TextStyle(fontFamily = Inter, fontSize = 30.sp),
-    headlineLarge = TextStyle(fontFamily = Inter, fontSize = 28.sp),
-    headlineMedium = TextStyle(fontFamily = Inter, fontSize = 24.sp),
-    headlineSmall = TextStyle(fontFamily = Inter, fontSize = 20.sp),
-    titleLarge = TextStyle(fontFamily = Inter, fontSize = 24.sp),
-    titleMedium = TextStyle(fontFamily = Inter, fontSize = 20.sp),
-    titleSmall = TextStyle(fontFamily = Inter, fontSize = 16.sp),
-    bodyLarge = TextStyle(fontFamily = Inter, fontSize = 16.sp),
-    bodyMedium = TextStyle(fontFamily = Inter, fontSize = 14.sp),
-    bodySmall = TextStyle(fontFamily = Inter, fontSize = 12.sp),
+    displayLarge = TextStyle(fontFamily = Inter, fontSize = 48.sp),
+    displayMedium = TextStyle(fontFamily = Inter, fontSize = 40.sp),
+    displaySmall = TextStyle(fontFamily = Inter, fontSize = 36.sp),
+    headlineLarge = TextStyle(fontFamily = Inter, fontSize = 30.sp),
+    headlineMedium = TextStyle(fontFamily = Inter, fontSize = 26.sp),
+    headlineSmall = TextStyle(fontFamily = Inter, fontSize = 22.sp),
+    titleLarge = TextStyle(fontFamily = Inter, fontSize = 28.sp),
+    titleMedium = TextStyle(fontFamily = Inter, fontSize = 24.sp),
+    titleSmall = TextStyle(fontFamily = Inter, fontSize = 20.sp),
+    bodyLarge = TextStyle(fontFamily = Inter, fontSize = 18.sp),
+    bodyMedium = TextStyle(fontFamily = Inter, fontSize = 16.sp),
+    bodySmall = TextStyle(fontFamily = Inter, fontSize = 14.sp),
     labelLarge = TextStyle(fontFamily = Inter, fontSize = 14.sp),
     labelMedium = TextStyle(fontFamily = Inter, fontSize = 12.sp),
-    labelSmall = TextStyle(fontFamily = Inter, fontSize = 10.sp),
+    labelSmall = TextStyle(fontFamily = Inter, fontSize = 11.sp),
 )
 
 @Composable


### PR DESCRIPTION
## Summary
- scale up text sizes for a clear hierarchy
- use medium text for food menu details
- bump text sizes in monthly menu and planner screens
- enlarge date on home screen and various labels

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_68614c70d668832fa431fc1f72fc8ba1