### PR TITLE
Fix weather widget width in SummaryCard

### DIFF
--- a/app/src/main/java/com/example/basic/SummaryCard.kt
+++ b/app/src/main/java/com/example/basic/SummaryCard.kt
@@ -101,8 +101,8 @@ fun SummaryCard() {
             }
         }
         Spacer(Modifier.height(16.dp))
-        val progressWidthFraction = 0.4f
-        val weatherWidthFraction = 0.35f
+        val progressWeight = 0.7f
+        val weatherWeight = 0.3f
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -112,17 +112,14 @@ fun SummaryCard() {
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(160.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 DayProgressBar(
-                    modifier = Modifier
-                        .fillMaxWidth(progressWidthFraction)
+                    modifier = Modifier.weight(progressWeight)
                 )
-                Spacer(modifier = Modifier.weight(1f))
                 WeatherCard(
-                    modifier = Modifier
-                        .fillMaxWidth(weatherWidthFraction)
+                    modifier = Modifier.weight(weatherWeight)
                 )
             }
             Spacer(Modifier.height(16.dp))


### PR DESCRIPTION
## Summary
- use `weight` in `SummaryCard` row so children can size proportionally
- set the weather card to occupy 30% of the row width

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615a2c40dc832fa8b5dce68b7df977