### PR TITLE
Fix weather widget width

### DIFF
--- a/app/src/main/java/com/example/basic/SummaryCard.kt
+++ b/app/src/main/java/com/example/basic/SummaryCard.kt
@@ -79,7 +79,7 @@ fun SummaryCard() {
                 .fillMaxWidth()
                 .padding(16.dp)
         ) {
-            WeatherCard()
+            WeatherCard(modifier = Modifier.align(Alignment.CenterHorizontally))
             Spacer(Modifier.height(16.dp)) 
             ClassSummaryBar()
  
@@ -121,13 +121,13 @@ private fun Color.darken(factor: Float = 0.8f): Color {
 }
 
 @Composable
-private fun WeatherCard() {
+private fun WeatherCard(modifier: Modifier = Modifier) {
     Card(
         shape = RoundedCornerShape(50.dp),
         colors = CardDefaults.cardColors(containerColor = Color.Transparent),
         elevation = CardDefaults.cardElevation(0.dp),
-        modifier = Modifier
-            .fillMaxWidth()
+        modifier = modifier
+            .width(LocalConfiguration.current.screenWidthDp.dp * 0.3f)
             .height(160.dp)
     ) {
         Box(


### PR DESCRIPTION
## Summary
- expose `modifier` parameter for `WeatherCard`
- set the widget width to 30% of screen width
- center `WeatherCard` in `SummaryCard`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615fd4fe8c832f98ef2ca3b7cb5fd4