### PR TITLE
Fix more screen schedule layout

### DIFF
--- a/app/src/main/java/com/example/basic/MoreScreen.kt
+++ b/app/src/main/java/com/example/basic/MoreScreen.kt
@@ -206,7 +206,7 @@ fun MoreScreen() {
         val hours = (0..23).map { hour ->
             val displayHour = if (hour % 12 == 0) 12 else hour % 12
             val ampm = if (hour < 12) "am" else "pm"
-            "%02d:00 %s".format(displayHour, ampm)
+            "$displayHour $ampm"
         }
         val calendarScroll = rememberScrollState()
         val dayClasses = WEEK_CLASSES[selectedDay] ?: emptyList()
@@ -259,7 +259,6 @@ fun MoreScreen() {
                                     color = lineColor,
                                     modifier = Modifier
                                         .align(Alignment.TopStart)
-                                        .padding(start = 4.dp)
                                         .fillMaxWidth(),
                                     thickness = 1.dp
                                 )
@@ -279,9 +278,7 @@ fun MoreScreen() {
                         ) {
                             Divider(
                                 color = lineColor,
-                                modifier = Modifier
-                                    .padding(start = 4.dp)
-                                    .fillMaxWidth(),
+                                modifier = Modifier.fillMaxWidth(),
                                 thickness = 1.dp
                             )
                         }
@@ -298,8 +295,8 @@ fun MoreScreen() {
                     val top = (startUnit * dpPerUnit).dp
                     val height = ((endUnit - startUnit) * dpPerUnit).dp
                     val color = when (cls.type) {
-                        ClassType.THEORY -> MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
-                        ClassType.LAB -> MaterialTheme.colorScheme.secondary.copy(alpha = 0.3f)
+                        ClassType.THEORY -> MaterialTheme.colorScheme.primary
+                        ClassType.LAB -> MaterialTheme.colorScheme.secondary
                         ClassType.BREAK, ClassType.LUNCH -> MaterialTheme.colorScheme.surfaceVariant
                     }
                     Box(


### PR DESCRIPTION
## Summary
- adjust hour formatting and remove leading zeros
- align hour lines with left margin
- ensure hour lines stay behind opaque class cards

## Testing
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686162e71548832fad8c0be718cfa009