### PR TITLE
Adjust spacing and layout on More page

### DIFF
--- a/app/src/main/java/com/example/basic/MoreScreen.kt
+++ b/app/src/main/java/com/example/basic/MoreScreen.kt
@@ -97,19 +97,19 @@ fun MoreScreen() {
         modifier = Modifier
             .fillMaxSize()
             .background(Brush.verticalGradient(listOf(gradientTop, gradientBottom)))
-            .padding(16.dp),
+            .padding(start = 12.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
             text = monthLabel,
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(vertical = 16.dp)
+            modifier = Modifier.padding(vertical = 8.dp)
         )
         Divider(
             color = dividerColor,
             thickness = 0.5.dp,
-            modifier = Modifier.padding(vertical = 12.dp)
+            modifier = Modifier.padding(vertical = 8.dp)
         )
         Row(
             modifier = Modifier
@@ -143,7 +143,7 @@ fun MoreScreen() {
         Divider(
             color = dividerColor,
             thickness = 0.5.dp,
-            modifier = Modifier.padding(vertical = 12.dp)
+            modifier = Modifier.padding(vertical = 8.dp)
         )
         // Compact information bar with a toggle icon on the right
         var expanded by remember { mutableStateOf(false) }
@@ -169,7 +169,8 @@ fun MoreScreen() {
                 Text(
                     text = "5 classes left \u00B7 4 hr 55 min free",
                     modifier = Modifier.weight(1f),
-                    color = MaterialTheme.colorScheme.onBackground
+                    color = MaterialTheme.colorScheme.onBackground,
+                    style = MaterialTheme.typography.bodyMedium
                 )
                 Icon(
                     imageVector = if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
@@ -189,7 +190,8 @@ fun MoreScreen() {
                         text = "More details about classes...",
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(start = 12.dp, end = 12.dp, bottom = 8.dp)
+                            .padding(start = 12.dp, end = 12.dp, bottom = 8.dp),
+                        style = MaterialTheme.typography.bodyMedium
                     )
                 }
             }
@@ -203,7 +205,7 @@ fun MoreScreen() {
         val unitsPerHour = 62f
         val dpPerUnit = hourHeight.value / unitsPerHour
         // Show the full day from midnight to 11 pm
-        val hours = (0..23).map { hour ->
+        val hours = listOf("11 pm") + (0..23).map { hour ->
             val displayHour = if (hour % 12 == 0) 12 else hour % 12
             val ampm = if (hour < 12) "am" else "pm"
             "$displayHour $ampm"
@@ -238,7 +240,8 @@ fun MoreScreen() {
                                     style = MaterialTheme.typography.bodyLarge,
                                     fontWeight = FontWeight.Bold,
                                     modifier = Modifier
-                                        .align(Alignment.TopCenter)
+                                        .align(Alignment.TopEnd)
+                                        .padding(end = 4.dp)
                                         // Shift labels slightly higher so
                                         // they line up with the hour divider
                                         .offset(y = (-12).dp)


### PR DESCRIPTION
## Summary
- tweak overall padding on More screen
- reduce spacing around month header and day row
- shrink text in schedule info bar
- insert an extra 11 pm label at the start of the schedule
- align hour labels closer to the divider

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861655223dc832fb1b9956d12a1de9e