### PR TITLE
Fix Kotlin utilities button layout

### DIFF
--- a/app/src/main/java/com/example/basic/SummaryCard.kt
+++ b/app/src/main/java/com/example/basic/SummaryCard.kt
@@ -33,8 +33,7 @@ import androidx.compose.material.icons.filled.WaterDrop
  
 import androidx.compose.material.icons.filled.Person
  
-import androidx.compose.material.icons.filled.UnfoldLess
-import androidx.compose.material.icons.filled.UnfoldMore
+import androidx.compose.material.icons.filled.KeyboardArrowDown
  
  
 import androidx.compose.material3.Card
@@ -314,44 +313,49 @@ private fun UtilitiesSection() {
         "Clock", "Calendar", "Notes", "Files",
         "Camera", "Maps", "Gallery", "Music"
     )
-    Column {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            IconButton(onClick = { expanded = !expanded }) {
-                Icon(
-                    imageVector = if (expanded) Icons.Filled.UnfoldLess else Icons.Filled.UnfoldMore,
-                    contentDescription = if (expanded) "Collapse" else "Expand"
-                )
-            }
+    Box {
+        Column {
             Row(
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 utilities.take(4).forEach { label ->
                     UtilityBox(label)
                 }
             }
-        }
-        if (expanded) {
-            utilities.drop(4).chunked(4).forEach { rowItems ->
-                Spacer(Modifier.height(8.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    rowItems.forEach { label ->
-                        UtilityBox(label)
-                    }
-                    if (rowItems.size < 4) {
-                        repeat(4 - rowItems.size) {
-                            Spacer(modifier = Modifier.width(72.dp))
+            if (expanded) {
+                utilities.drop(4).chunked(4).forEach { rowItems ->
+                    Spacer(Modifier.height(8.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        rowItems.forEach { label ->
+                            UtilityBox(label)
+                        }
+                        if (rowItems.size < 4) {
+                            repeat(4 - rowItems.size) {
+                                Spacer(modifier = Modifier.width(72.dp))
+                            }
                         }
                     }
                 }
             }
+        }
+        IconButton(
+            onClick = { expanded = !expanded },
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(top = 8.dp)
+                .size(32.dp)
+                .background(MaterialTheme.colorScheme.surface, CircleShape)
+                .border(BorderStroke(1.dp, Color(0xFFE0E0E0)), CircleShape)
+        ) {
+            Icon(
+                imageVector = Icons.Filled.KeyboardArrowDown,
+                contentDescription = if (expanded) "Collapse" else "Expand",
+                tint = MaterialTheme.colorScheme.onSurface
+            )
         }
     }
 }

--- a/vit-student-app/src/components/BottomPanel.tsx
+++ b/vit-student-app/src/components/BottomPanel.tsx
@@ -12,6 +12,7 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  Pressable,
   View,
 } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
@@ -92,9 +93,10 @@ const BottomPanel = forwardRef<BottomPanelHandle, Props>(
           !isVisible && { pointerEvents: 'none' },
         ]}
       >
-        <View style={styles.handleContainer}>
-          <View style={styles.handleBar} />
-        </View>
+        {/* Floating close button */}
+        <Pressable style={styles.closeButton} onPress={() => slideDown()}>
+          <Ionicons name="chevron-down" size={20} color="#333" />
+        </Pressable>
 
         <ScrollView
           style={styles.scrollContent}
@@ -153,17 +155,6 @@ const styles = StyleSheet.create({
     elevation: 0,
     zIndex: 10,
   },
-  handleContainer: {
-    height: 24,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  handleBar: {
-    width: 60,
-    height: 6,
-    backgroundColor: '#ccc',
-    borderRadius: 3,
-  },
   scrollContent: {
     paddingHorizontal: 16,
   },
@@ -191,7 +182,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   utilityItem: {
-    width: '30%',
+    width: '24%',
     alignItems: 'center',
     marginVertical: 12,
   },
@@ -202,5 +193,14 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: '#333',
     textAlign: 'center',
+  },
+  closeButton: {
+    position: 'absolute',
+    bottom: 8,
+    alignSelf: 'center',
+    backgroundColor: '#fff',
+    borderRadius: 20,
+    padding: 6,
+    elevation: 2,
   },
 });


### PR DESCRIPTION
## Summary
- change SummaryCard utilities section
- replace double-arrow expand button with floating downward button
- ensure utilities grid starts at left edge

## Testing
- `npm test` *(fails: package.json missing)*
- `./gradlew test` *(fails: gradle-wrapper.jar missing)*

------
https://chatgpt.com/codex/tasks/task_e_68616a4a87fc832fb9adc6d91aaf4276