### PR TITLE
Fix Kotlin utilities button layout

### DIFF
--- a/app/src/main/java/com/example/basic/SummaryCard.kt
+++ b/app/src/main/java/com/example/basic/SummaryCard.kt
@@ -30,11 +30,16 @@ import androidx.compose.material.icons.filled.Fastfood
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.WaterDrop
- 
 import androidx.compose.material.icons.filled.Person
- 
-import androidx.compose.material.icons.filled.UnfoldLess
-import androidx.compose.material.icons.filled.UnfoldMore
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.AccessTime
+import androidx.compose.material.icons.filled.Event
+import androidx.compose.material.icons.filled.Note
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.Camera
+import androidx.compose.material.icons.filled.Map
+import androidx.compose.material.icons.filled.Photo
+import androidx.compose.material.icons.filled.MusicNote
  
  
 import androidx.compose.material3.Card
@@ -278,7 +283,7 @@ private fun ClassSummaryBar() {
 }
 
 @Composable
-private fun UtilityBox(label: String) {
+private fun UtilityBox(icon: ImageVector, label: String) {
     Card(
         modifier = Modifier
             .width(72.dp)
@@ -295,9 +300,16 @@ private fun UtilityBox(label: String) {
             Box(
                 modifier = Modifier
                     .size(32.dp)
-                    .clip(RoundedCornerShape(4.dp))
-                    .background(MaterialTheme.colorScheme.primary)
-            )
+                    .clip(RoundedCornerShape(4.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = label,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
             Spacer(Modifier.height(8.dp))
             Text(label, style = MaterialTheme.typography.bodyMedium)
         }
@@ -311,47 +323,59 @@ private fun UtilitiesSection() {
     SectionHeader("Utilities")
     var expanded by remember { mutableStateOf(false) }
     val utilities = listOf(
-        "Clock", "Calendar", "Notes", "Files",
-        "Camera", "Maps", "Gallery", "Music"
+        Icons.Filled.AccessTime to "Clock",
+        Icons.Filled.Event to "Calendar",
+        Icons.Filled.Note to "Notes",
+        Icons.Filled.Folder to "Files",
+        Icons.Filled.Camera to "Camera",
+        Icons.Filled.Map to "Maps",
+        Icons.Filled.Photo to "Gallery",
+        Icons.Filled.MusicNote to "Music"
     )
-    Column {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            IconButton(onClick = { expanded = !expanded }) {
-                Icon(
-                    imageVector = if (expanded) Icons.Filled.UnfoldLess else Icons.Filled.UnfoldMore,
-                    contentDescription = if (expanded) "Collapse" else "Expand"
-                )
-            }
+    Box {
+        Column {
             Row(
-                modifier = Modifier.weight(1f),
-                horizontalArrangement = Arrangement.SpaceBetween
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly
             ) {
-                utilities.take(4).forEach { label ->
-                    UtilityBox(label)
+                utilities.take(4).forEach { (icon, label) ->
+                    UtilityBox(icon, label)
                 }
             }
-        }
-        if (expanded) {
-            utilities.drop(4).chunked(4).forEach { rowItems ->
-                Spacer(Modifier.height(8.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    rowItems.forEach { label ->
-                        UtilityBox(label)
-                    }
-                    if (rowItems.size < 4) {
-                        repeat(4 - rowItems.size) {
-                            Spacer(modifier = Modifier.width(72.dp))
+            if (expanded) {
+                utilities.drop(4).chunked(4).forEach { rowItems ->
+                    Spacer(Modifier.height(8.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceEvenly
+                    ) {
+                        rowItems.forEach { (icon, label) ->
+                            UtilityBox(icon, label)
+                        }
+                        if (rowItems.size < 4) {
+                            repeat(4 - rowItems.size) {
+                                Spacer(modifier = Modifier.width(72.dp))
+                            }
                         }
                     }
                 }
             }
+        }
+        IconButton(
+            onClick = { expanded = !expanded },
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(start = 8.dp, top = 8.dp)
+                .size(14.dp)
+                .background(MaterialTheme.colorScheme.surface, CircleShape)
+                .border(BorderStroke(1.dp, Color(0xFFE0E0E0)), CircleShape)
+        ) {
+            Icon(
+                imageVector = Icons.Filled.KeyboardArrowDown,
+                contentDescription = if (expanded) "Collapse" else "Expand",
+                tint = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.size(12.dp)
+            )
         }
     }
 }

--- a/vit-student-app/src/components/BottomPanel.tsx
+++ b/vit-student-app/src/components/BottomPanel.tsx
@@ -12,6 +12,7 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  Pressable,
   View,
 } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
@@ -92,9 +93,10 @@ const BottomPanel = forwardRef<BottomPanelHandle, Props>(
           !isVisible && { pointerEvents: 'none' },
         ]}
       >
-        <View style={styles.handleContainer}>
-          <View style={styles.handleBar} />
-        </View>
+        {/* Floating close button */}
+        <Pressable style={styles.closeButton} onPress={() => slideDown()}>
+          <Ionicons name="chevron-down" size={12} color="#333" />
+        </Pressable>
 
         <ScrollView
           style={styles.scrollContent}
@@ -153,17 +155,6 @@ const styles = StyleSheet.create({
     elevation: 0,
     zIndex: 10,
   },
-  handleContainer: {
-    height: 24,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  handleBar: {
-    width: 60,
-    height: 6,
-    backgroundColor: '#ccc',
-    borderRadius: 3,
-  },
   scrollContent: {
     paddingHorizontal: 16,
   },
@@ -188,10 +179,10 @@ const styles = StyleSheet.create({
   utilityGrid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    justifyContent: 'space-between',
+    justifyContent: 'space-evenly',
   },
   utilityItem: {
-    width: '30%',
+    width: '24%',
     alignItems: 'center',
     marginVertical: 12,
   },
@@ -202,5 +193,14 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: '#333',
     textAlign: 'center',
+  },
+  closeButton: {
+    position: 'absolute',
+    bottom: 8,
+    left: 16,
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    padding: 1,
+    elevation: 2,
   },
 });


### PR DESCRIPTION
## Summary
- change SummaryCard utilities section
- replace double-arrow expand button with floating downward button
- ensure utilities grid starts at left edge
- shrink floating button, move to left
- add icons for each utility
- center utility rows better
- reduce arrow size further and remove icon background color
- **shrink background circle for down-arrow button**
- reduce button size instead of icon

## Testing
- `npm test` *(fails: package.json missing)*
- `./gradlew test` *(fails: gradle-wrapper.jar missing)*

------
https://chatgpt.com/codex/tasks/task_e_68616a4a87fc832fb9adc6d91aaf4276