### PR TITLE
Fix pager swipe interference with menu scroll

### DIFF
--- a/app/src/main/java/com/example/basic/SummaryCard.kt
+++ b/app/src/main/java/com/example/basic/SummaryCard.kt
@@ -22,6 +22,8 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.draw.clip
@@ -392,10 +394,16 @@ private fun MenuSection(contentPadding: Dp) {
         "Snacks" to "Fruit & Yogurt",
         "Dinner" to "Salmon & Veggies"
     )
+    val scrollState = rememberScrollState()
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .horizontalScroll(rememberScrollState())
+            .pointerInput(Unit) {
+                detectHorizontalDragGestures { change, _ ->
+                    change.consume()
+                }
+            }
+            .horizontalScroll(scrollState)
             .padding(horizontal = contentPadding),
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {


### PR DESCRIPTION
## Summary
- prevent page swipe in `SummaryCard` when scrolling today's menu by consuming horizontal drag events
- add missing import for `pointerInput`

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_686173188290832f8d172b5f0fcb96ce